### PR TITLE
COH-29: Cohort resource custom representation post commit

### DIFF
--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
@@ -38,9 +38,11 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		if (Context.isAuthenticated()) {
-			DelegatingResourceDescription description = new DelegatingResourceDescription();
+
+			DelegatingResourceDescription description = null;
 
 			if (rep instanceof DefaultRepresentation) {
+				description = new DelegatingResourceDescription();
 				description.addProperty("name");
 				description.addProperty("description");
 				description.addProperty("location");
@@ -55,6 +57,9 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				description.addSelfLink();
 				return description;
 			} else if (rep instanceof FullRepresentation) {
+
+				description = new DelegatingResourceDescription();
+
 				description.addProperty("name");
 				description.addProperty("description");
 				description.addProperty("location");

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
@@ -48,6 +48,10 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				description.addProperty("location");
 				description.addProperty("startDate");
 				description.addProperty("endDate");
+				description.addProperty("cohortType");
+				description.addProperty("cohortProgram");
+				description.addProperty("cohortLeaders");
+				description.addProperty("cohortVisits");
 				description.addProperty("attributes");
 				description.addProperty("groupCohort");
 				description.addProperty("uuid");


### PR DESCRIPTION
With custom request to cohort resource 
_amrs/ws/rest/v1/cohortm/cohort?location=08feae7c-1352-11df-a1f1-0026b9348838&v=custom:(uuid,name,description)_
The endpoint still returns undesired response
![image](https://user-images.githubusercontent.com/18227275/124439963-bb223400-dd82-11eb-8b18-bf20b3a90e3f.png)


The second commit is to enable us to get all the required properties for cohort resource while ignoring the circular dependancy between CohortMember and Cohort Resource while doing **v=full**