### PR TITLE
Change column attribute_type_id to cohort_member_attribute_type_id

### DIFF
--- a/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttributeType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttributeType.java
@@ -19,5 +19,15 @@ public class CohortMemberAttributeType extends BaseAttributeType<CohortMember> {
 
     @Getter
     @Setter
-    private Integer id;
+    private Integer cohortMemberAttributeTypeId;
+
+    @Override
+    public Integer getId() {
+        return cohortMemberAttributeTypeId;
+    }
+
+    @Override
+    public void setId(Integer id) {
+        this.cohortMemberAttributeTypeId = id;
+    }
 }

--- a/api/src/main/resources/CohortMemberAttributeType.hbm.xml
+++ b/api/src/main/resources/CohortMemberAttributeType.hbm.xml
@@ -16,7 +16,7 @@
 
 <hibernate-mapping package="org.openmrs.module.cohort">
     <class name="CohortMemberAttributeType" table="cohort_member_attribute_type">
-        <id name="id" type="int" column="attribute_type_id">
+        <id name="cohortMemberAttributeTypeId" type="int" column="cohort_member_attribute_type_id">
             <generator class="native">
                 <param name="sequence">cohort_member_attribute_type_id_seq</param>
             </generator>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -545,7 +545,7 @@
             </not>
         </preConditions>
         <createTable tableName="cohort_member_attribute_type">
-            <column name="attribute_type_id" autoIncrement="true" type="int(11)">
+            <column name="cohort_member_attribute_type_id" autoIncrement="true" type="int(11)">
                 <constraints nullable="false" primaryKey="true"/>
             </column>
             <column name="name" type="varchar(255)">

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml
@@ -9,10 +9,10 @@
     graphic logo is a trademark of OpenMRS Inc.
 -->
 <dataset>
-    <cohort_member_attribute_type attribute_type_id="1" name="cohort member attribute type" datatype="String"
+    <cohort_member_attribute_type cohort_member_attribute_type_id="1" name="cohort member attribute type" datatype="String"
                             description="This is description" creator="1" date_created="2021-01-01 00:00:00.0" retired="false"
                             min_occurs="1" uuid="9eb7fe43-2813-4ebc-80dc-2e5d30251bb7"/>
-    <cohort_member_attribute_type attribute_type_id="2" name="Voided cohort member attribute type" datatype="String"
+    <cohort_member_attribute_type cohort_member_attribute_type_id="2" name="Voided cohort member attribute type" datatype="String"
                                   description="This is voided cohort member attribute type description" creator="1" date_created="2021-01-01 00:00:00.0" retired="true"
                                   retired_by="1" date_retired="2020-01-01 00:00:00.0" retire_reason="This is retired"
                                   min_occurs="1" uuid="8gh7fe43-2813-4ebc-80dc-2e5d30251lk2"/>


### PR DESCRIPTION
- Fix typo 

I think there not need to add a new changeset since this (`cohort_member_attribute_type table`) has never been used in production.