### PR TITLE
Standardize code format, imports & license header

### DIFF
--- a/api-hfe/pom.xml
+++ b/api-hfe/pom.xml
@@ -88,4 +88,8 @@
             </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
 </project>

--- a/api-hfe/pom.xml
+++ b/api-hfe/pom.xml
@@ -76,5 +76,16 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormEntrySession.java
+++ b/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormEntrySession.java
@@ -1,11 +1,11 @@
 package org.openmrs.module.cohort.hfe;
 
+import javax.servlet.http.HttpSession;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,7 +32,7 @@ public class CohortFormEntrySession extends FormEntrySession {
 	
 	protected final Log log = LogFactory.getLog(getClass());
 	
-	public final static String[] COHORT_TAGS = {"cohort"};
+	public final static String[] COHORT_TAGS = { "cohort" };
 	
 	private CohortM cohort;
 	
@@ -58,24 +58,23 @@ public class CohortFormEntrySession extends FormEntrySession {
 		this(cohort, htmlForm, Mode.ENTER, httpSession);
 	}
 	
-	
 	public CohortFormEntrySession(CohortM cohort, HtmlForm htmlForm, Mode mode, HttpSession httpSession) throws Exception {
 		this(cohort, null, htmlForm, mode, null, httpSession, true, false);
 	}
 	
 	public CohortFormEntrySession(CohortM cohort, CohortEncounter encounter, HtmlForm htmlForm, Mode mode,
-			Location defaultLocation, HttpSession httpSession,
-			boolean automaticClientSideValidation,
-			boolean clientSideValidationHints) throws Exception {
-		super(null, null/*convertToEncounter(encounter)*/, mode, htmlForm, defaultLocation, httpSession, automaticClientSideValidation, clientSideValidationHints);
+	    Location defaultLocation, HttpSession httpSession, boolean automaticClientSideValidation,
+	    boolean clientSideValidationHints) throws Exception {
+		super(null, null/*convertToEncounter(encounter)*/, mode, htmlForm, defaultLocation, httpSession,
+		        automaticClientSideValidation, clientSideValidationHints);
 		this.htmlForm = htmlForm;
 		this.encounter = convertToEncounter(encounter);
 		this.cohortEncounter = encounter;
 		this.cohort = cohort;
 	}
 	
-	public CohortFormEntrySession(CohortM cohort, CohortEncounter encounter,
-			Mode mode, HtmlForm htmlForm, HttpSession session) throws Exception {
+	public CohortFormEntrySession(CohortM cohort, CohortEncounter encounter, Mode mode, HtmlForm htmlForm,
+	    HttpSession session) throws Exception {
 		this(cohort, encounter, htmlForm, mode, null, session, true, false);
 	}
 	
@@ -117,7 +116,8 @@ public class CohortFormEntrySession extends FormEntrySession {
 		{
 			for (Encounter e : getSubmissionActions().getEncountersToCreate()) {
 				if (!HtmlFormEntryUtil.hasProvider(e) || e.getEncounterDatetime() == null || e.getLocation() == null) {
-					throw new BadFormDesignException("Please check the design of your form to make sure it has all three tags: <b>&lt;encounterDate/&gt</b>;, <b>&lt;encounterLocation/&gt</b>;, and <b>&lt;encounterProvider/&gt;</b>");
+					throw new BadFormDesignException(
+					        "Please check the design of your form to make sure it has all three tags: <b>&lt;encounterDate/&gt</b>;, <b>&lt;encounterLocation/&gt</b>;, and <b>&lt;encounterProvider/&gt;</b>");
 				}
 			}
 		}
@@ -135,7 +135,7 @@ public class CohortFormEntrySession extends FormEntrySession {
 					o.setObsDatetime(o.getEncounter().getEncounterDatetime());
 					if (log.isDebugEnabled()) {
 						log.debug("Set obsDatetime to " + o.getObsDatetime() + " for "
-								+ o.getConcept().getName(Context.getLocale(), false));
+						        + o.getConcept().getName(Context.getLocale(), false));
 					}
 				}
 				if (o.getLocation() == null && o.getEncounter() != null) {
@@ -153,9 +153,9 @@ public class CohortFormEntrySession extends FormEntrySession {
 				if (p instanceof CohortM) {
 					CohortM cohort = p;
 					if (!StringUtils.hasText(cohort.getName()) || !StringUtils.hasText(cohort.getDescription())
-							|| cohort.getStartDate() == null || cohort.getEndDate() == null) {
+					        || cohort.getStartDate() == null || cohort.getEndDate() == null) {
 						throw new BadFormDesignException(
-								"Please check the design of your form to make sure the following fields are mandatory to create a patient: <br/><b>&lt;personName/&gt;</b>, <b>&lt;birthDateOrAge/&gt;</b>, <b>&lt;gender/&gt;</b>, <b>&lt;identifierType/&gt;</b>, <b>&lt;identifier/&gt;</b>, and <b>&lt;identifierLocation/&gt;</b>");
+						        "Please check the design of your form to make sure the following fields are mandatory to create a patient: <br/><b>&lt;personName/&gt;</b>, <b>&lt;birthDateOrAge/&gt;</b>, <b>&lt;gender/&gt;</b>, <b>&lt;identifierType/&gt;</b>, <b>&lt;identifier/&gt;</b>, and <b>&lt;identifierLocation/&gt;</b>");
 					}
 				}
 				Context.getService(CohortService.class).saveCohort(cohort);
@@ -216,7 +216,7 @@ public class CohortFormEntrySession extends FormEntrySession {
 			
 			//Context.getObsService().saveObs(o, null);
 		}
-//TODO Add Obs Creation line from FormENtrySession 
+		//TODO Add Obs Creation line from FormENtrySession 
 		// If we're in EDIT mode, we have to save the encounter so that any new obs are created.
 		// This feels a bit like a hack, but actually it's a good thing to update the encounter's dateChanged in this case. (PS- turns out there's no dateChanged on encounter up to 1.5.)
 		// If there is no encounter (impossible at the time of writing this comment) we save the obs manually
@@ -241,7 +241,8 @@ public class CohortFormEntrySession extends FormEntrySession {
 		
 		// handle any custom actions (for an example of a custom action, see: https://github.com/PIH/openmrs-module-appointmentschedulingui/commit/e2cda8de1caa8a45d319ae4fbf7714c90c9adb8b)
 		if (getSubmissionActions().getCustomFormSubmissionActions() != null) {
-			for (CustomFormSubmissionAction customFormSubmissionAction : getSubmissionActions().getCustomFormSubmissionActions()) {
+			for (CustomFormSubmissionAction customFormSubmissionAction : getSubmissionActions()
+			        .getCustomFormSubmissionActions()) {
 				customFormSubmissionAction.applyAction(this);
 			}
 		}
@@ -256,7 +257,8 @@ public class CohortFormEntrySession extends FormEntrySession {
 		if (hasCohortTag() && !hasEncouterTag()) {
 			try {
 				submissionActions.beginCohort(cohort);
-			} catch (InvalidActionException e) {
+			}
+			catch (InvalidActionException e) {
 				log.error("Programming error: should be no errors starting a patient", e);
 			}
 		} else {
@@ -271,7 +273,8 @@ public class CohortFormEntrySession extends FormEntrySession {
 				// TODO cohort specific submissionActions.beginPerson(patient);
 				submissionActions.beginCohort(cohort);
 				submissionActions.beginEncounter(encounter);
-			} catch (InvalidActionException e) {
+			}
+			catch (InvalidActionException e) {
 				log.error("Programming error: should be no errors starting a patient and encounter", e);
 			}
 		}

--- a/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormEntrySession.java
+++ b/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormEntrySession.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.hfe;
 
 import javax.servlet.http.HttpSession;

--- a/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
+++ b/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.hfe;
 
 import java.util.Date;

--- a/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
+++ b/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
@@ -49,9 +49,9 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	
 	private List<Encounter> encountersToEdit = new Vector<Encounter>();
 	
-	private List<Obs> obsToCreate = new Vector<Obs>();
+	private List<Obs> obsToCreate = new Vector<>();
 	
-	private List<Obs> obsToVoid = new Vector<Obs>();
+	private List<Obs> obsToVoid = new Vector<>();
 	
 	/**
 	 * The stack where state is stored

--- a/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
+++ b/api-hfe/src/main/java/org/openmrs/module/cohort/hfe/CohortFormSubmissionActions.java
@@ -12,7 +12,6 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
-import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.cohort.CohortEncounter;
 import org.openmrs.module.cohort.CohortM;
@@ -62,8 +61,8 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Removes the most recently added Person from the submission stack. All other objects added
-	 * after that Person are removed as well.
+	 * Removes the most recently added Person from the submission stack. All other objects added after
+	 * that Person are removed as well.
 	 * <p/>
 	 * (So, in the current one-person-per-form model, this would empty the entire submission stack)
 	 *
@@ -102,8 +101,8 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Removes the most recently added Encounter from the submission stack. All objects added after
-	 * that Encounter are removed as well.
+	 * Removes the most recently added Encounter from the submission stack. All objects added after that
+	 * Encounter are removed as well.
 	 *
 	 * @throws InvalidActionException
 	 */
@@ -150,8 +149,8 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Utility function that adds a set of Obs to an Encounter, skipping Obs that are already part
-	 * of the Encounter
+	 * Utility function that adds a set of Obs to an Encounter, skipping Obs that are already part of
+	 * the Encounter
 	 *
 	 * @param encounter
 	 * @param group
@@ -166,8 +165,8 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Removes the most recently added ObsGroup from the submission stack. All objects added after
-	 * that ObsGroup are removed as well.
+	 * Removes the most recently added ObsGroup from the submission stack. All objects added after that
+	 * ObsGroup are removed as well.
 	 *
 	 * @throws InvalidActionException
 	 */
@@ -203,12 +202,12 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Utility method that returns the object of a specified class that was most recently added to
-	 * the stack
+	 * Utility method that returns the object of a specified class that was most recently added to the
+	 * stack
 	 */
 	@SuppressWarnings("unchecked")
 	private <T> T highestOnStack(Class<T> clazz) {
-		for (ListIterator<Object> iter = stack.listIterator(stack.size()); iter.hasPrevious(); ) {
+		for (ListIterator<Object> iter = stack.listIterator(stack.size()); iter.hasPrevious();) {
 			Object o = iter.previous();
 			if (clazz.isAssignableFrom(o.getClass())) {
 				return (T) o;
@@ -230,17 +229,17 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	}
 	
 	/**
-	 * Creates an new Obs and associates with the most recently added Person, Encounter, and
-	 * ObsGroup (if applicable) on the stack.
+	 * Creates an new Obs and associates with the most recently added Person, Encounter, and ObsGroup
+	 * (if applicable) on the stack.
 	 * <p/>
-	 * Note that this method does not actually commit the Obs to the database, but instead adds the
-	 * Obs to a list of Obs to be added. The changes are applied elsewhere in the framework.
+	 * Note that this method does not actually commit the Obs to the database, but instead adds the Obs
+	 * to a list of Obs to be added. The changes are applied elsewhere in the framework.
 	 *
-	 * @param concept         concept associated with the Obs
-	 * @param value           value for the Obs
-	 * @param datetime        date information for the Obs
+	 * @param concept concept associated with the Obs
+	 * @param value value for the Obs
+	 * @param datetime date information for the Obs
 	 * @param accessionNumber accession number for the Obs
-	 * @param comment         comment for the obs
+	 * @param comment comment for the obs
 	 * @return the Obs to create
 	 */
 	public Obs createObs(Concept concept, Object value, Date datetime, String accessionNumber, String comment) {
@@ -282,22 +281,22 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 		return createObs(concept, value, datetime, accessionNumber, null);
 	}
 	
-	
 	/**
 	 * Modifies an existing Obs.
 	 * <p/>
-	 * This method works by adding the current Obs to a list of Obs to void, and then adding the new
-	 * Obs to a list of Obs to create. Note that this method does not commit the changes to the
+	 * This method works by adding the current Obs to a list of Obs to void, and then adding the new Obs
+	 * to a list of Obs to create. Note that this method does not commit the changes to the
 	 * database--the changes are applied elsewhere in the framework.
 	 *
-	 * @param existingObs     the Obs to modify
-	 * @param concept         concept associated with the Obs
-	 * @param newValue        the new value of the Obs
-	 * @param newDatetime     the new date information for the Obs
+	 * @param existingObs the Obs to modify
+	 * @param concept concept associated with the Obs
+	 * @param newValue the new value of the Obs
+	 * @param newDatetime the new date information for the Obs
 	 * @param accessionNumber new accession number for the Obs
-	 * @param comment         comment for the obs
+	 * @param comment comment for the obs
 	 */
-	public void modifyObs(Obs existingObs, Concept concept, Object newValue, Date newDatetime, String accessionNumber, String comment) {
+	public void modifyObs(Obs existingObs, Concept concept, Object newValue, Date newDatetime, String accessionNumber,
+	        String comment) {
 		if (newValue == null || "".equals(newValue)) {
 			// we want to delete the existing obs
 			if (log.isDebugEnabled()) {
@@ -324,7 +323,7 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 		// TODO: handle dates that may equal encounter date
 		boolean dateChanged = dateChangedHelper(existingObs.getObsDatetime(), newObs.getObsDatetime());
 		boolean accessionNumberChanged = accessionNumberChangedHelper(existingObs.getAccessionNumber(),
-				newObs.getAccessionNumber());
+		    newObs.getAccessionNumber());
 		boolean conceptsHaveChanged = false;
 		if (!existingObs.getConcept().getConceptId().equals(concept.getConceptId())) {
 			conceptsHaveChanged = true;
@@ -400,7 +399,6 @@ public class CohortFormSubmissionActions extends FormSubmissionActions {
 	public List<CohortM> getCohortsToCreate() {
 		return cohortsToCreate;
 	}
-	
 	
 	/**
 	 * Sets the list of Cohorts that need to be created to process form submission

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -67,5 +67,16 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -79,4 +79,8 @@
             </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
 </project>

--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
@@ -7,9 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+
 import java.util.Date;
 
 import org.openmrs.BaseOpenmrsData;
@@ -18,56 +17,56 @@ import org.openmrs.api.context.Context;
 @Entity
 @Table(name = "cohort_attribute")
 public class CohortAttribute extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_attribute_id")
 	private Integer cohortAttributeId;
-
+	
 	@ManyToOne
 	@JoinColumn(name = "cohort_id")
 	private CohortM cohort;
-
+	
 	private String value;
-
+	
 	@ManyToOne
 	@JoinColumn(name = "cohort_attribute_type_id")
 	private CohortAttributeType cohortAttributeType;
-
+	
 	public Integer getCohortAttributeId() {
 		return cohortAttributeId;
 	}
-
+	
 	public void setCohortAttributeId(Integer cohortAttributeId) {
 		this.cohortAttributeId = cohortAttributeId;
 	}
-
+	
 	public CohortM getCohort() {
 		return cohort;
 	}
-
+	
 	public void setCohort(CohortM cohort) {
 		this.cohort = cohort;
 	}
-
+	
 	public String getValue() {
 		return value;
 	}
-
+	
 	public void setValue(String value) {
 		this.value = value;
 	}
-
+	
 	public CohortAttributeType getCohortAttributeType() {
 		return cohortAttributeType;
 	}
-
+	
 	public void setCohortAttributeType(CohortAttributeType cohortAttributeType) {
 		this.cohortAttributeType = cohortAttributeType;
 	}
-
+	
 	/**
 	 * Convenience method for voiding this attribute
 	 *
@@ -80,16 +79,16 @@ public class CohortAttribute extends BaseOpenmrsData {
 		setVoidReason(reason);
 		setDateVoided(new Date());
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortAttributeId();
 	}
-
+	
 	@Override
 	public void setId(Integer arg0) {
 		setCohortAttributeId(arg0);
-
+		
 	}
-
+	
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.Column;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.Column;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
@@ -12,65 +12,65 @@ import org.openmrs.BaseOpenmrsData;
 @Entity
 @Table(name = "cohort_attributes_type")
 public class CohortAttributeType extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_attribute_type_id")
 	private Integer cohortAttributeTypeId;
-
+	
 	private String name;
-
+	
 	private String description;
-
+	
 	private String format;
-
+	
 	public Integer getCohortAttributeTypeId() {
 		return cohortAttributeTypeId;
 	}
-
+	
 	public void setCohortAttributeTypeId(Integer cohortAttributeTypeId) {
 		this.cohortAttributeTypeId = cohortAttributeTypeId;
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		this.name = name;
 	}
-
+	
 	public String getDescription() {
 		return description;
 	}
-
+	
 	public void setDescription(String description) {
 		this.description = description;
 	}
-
+	
 	public String getFormat() {
 		return format;
 	}
-
+	
 	public void setFormat(String format) {
 		this.format = format;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortAttributeTypeId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortAttributeTypeId(id);
 	}
-
+	
 	@Override
 	public String toString() {
 		return this.name;
 	}
-
+	
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortEncounter.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortEncounter.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 
 package org.openmrs.module.cohort;
 

--- a/api/src/main/java/org/openmrs/module/cohort/CohortEncounter.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortEncounter.java
@@ -8,11 +8,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.openmrs.BaseOpenmrsData;
 import org.openmrs.EncounterProvider;
@@ -41,122 +40,122 @@ import org.openmrs.api.handler.VoidHandler;
 @Entity
 @Table(name = "cohort_encounter")
 public class CohortEncounter extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_id")
 	private Integer encounterId;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_id", insertable = false, updatable = false)
 	private CohortM cohort;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "encounter_type_id")
 	private EncounterType encounterType;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "location_id")
 	private Location location;
-
+	
 	@Column(name = "encounter_datetime")
 	private Date encounterDatetime;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "form_id")
 	private Form form;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_visit_id")
 	private CohortVisit visit;
-
+	
 	@OneToMany(mappedBy = "encounter")
 	private Set<CohortObs> obs;
-
+	
 	@OneToMany(mappedBy = "encounter", cascade = CascadeType.ALL)
 	@OrderBy("provider_id")
 	@DisableHandlers(handlerTypes = { VoidHandler.class })
 	private Set<EncounterProvider> encounterProviders = new LinkedHashSet<>();
-
+	
 	public Integer getEncounterId() {
 		return encounterId;
 	}
-
+	
 	public void setEncounterId(Integer encounterId) {
 		this.encounterId = encounterId;
 	}
-
+	
 	public CohortM getCohort() {
 		return cohort;
 	}
-
+	
 	public void setCohort(CohortM cohort) {
 		this.cohort = cohort;
 	}
-
+	
 	public EncounterType getEncounterType() {
 		return encounterType;
 	}
-
+	
 	public void setEncounterType(EncounterType encounterType) {
 		this.encounterType = encounterType;
 	}
-
+	
 	public Location getLocation() {
 		return location;
 	}
-
+	
 	public void setLocation(Location location) {
 		this.location = location;
 	}
-
+	
 	public Date getEncounterDatetime() {
 		return encounterDatetime;
 	}
-
+	
 	public void setEncounterDatetime(Date encounterDatetime) {
 		this.encounterDatetime = encounterDatetime;
 	}
-
+	
 	public Form getForm() {
 		return form;
 	}
-
+	
 	public void setForm(Form form) {
 		this.form = form;
 	}
-
+	
 	public CohortVisit getVisit() {
 		return visit;
 	}
-
+	
 	public void setVisit(CohortVisit visit) {
 		this.visit = visit;
 	}
-
+	
 	public Set<EncounterProvider> getEncounterProviders() {
 		return encounterProviders;
 	}
-
+	
 	public void setEncounterProviders(Set<EncounterProvider> encounterProviders) {
 		this.encounterProviders = encounterProviders;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getEncounterId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setEncounterId(id);
 	}
-
+	
 	public void setProvider(EncounterRole role, Provider provider) {
 		boolean hasProvider = false;
-		for (Iterator<EncounterProvider> it = encounterProviders.iterator(); it.hasNext(); ) {
+		for (Iterator<EncounterProvider> it = encounterProviders.iterator(); it.hasNext();) {
 			EncounterProvider encounterProvider = it.next();
 			if (encounterProvider.getEncounterRole().equals(role)) {
 				if (!encounterProvider.getProvider().equals(provider)) {
@@ -168,12 +167,12 @@ public class CohortEncounter extends BaseOpenmrsData {
 				}
 			}
 		}
-
+		
 		if (!hasProvider) {
 			addProvider(role, provider);
 		}
 	}
-
+	
 	public void addProvider(EncounterRole role, Provider provider) {
 		// first, make sure the provider isn't already there
 		for (EncounterProvider ep : encounterProviders) {
@@ -181,7 +180,7 @@ public class CohortEncounter extends BaseOpenmrsData {
 				return;
 			}
 		}
-
+		
 		EncounterProvider encounterProvider = new EncounterProvider();
 		//encounterProvider.setEncounter(this);
 		encounterProvider.setEncounterRole(role);
@@ -190,10 +189,10 @@ public class CohortEncounter extends BaseOpenmrsData {
 		encounterProvider.setCreator(Context.getAuthenticatedUser());
 		encounterProviders.add(encounterProvider);
 	}
-
+	
 	public Set<CohortObs> getObs() {
 		Set<CohortObs> ret = new HashSet<CohortObs>();
-
+		
 		if (this.obs != null) {
 			for (CohortObs o : this.obs) {
 				ret.addAll(getObsLeaves(o));
@@ -201,10 +200,10 @@ public class CohortEncounter extends BaseOpenmrsData {
 		}
 		return ret;
 	}
-
+	
 	private List<CohortObs> getObsLeaves(CohortObs obsParent) {
 		List<CohortObs> leaves = new ArrayList<>();
-
+		
 		if (obsParent.hasGroupMembers()) {
 			for (CohortObs child : obsParent.getGroupMembers()) {
 				if (!child.getVoided()) {
@@ -219,17 +218,17 @@ public class CohortEncounter extends BaseOpenmrsData {
 		} else if (!obsParent.getVoided()) {
 			leaves.add(obsParent);
 		}
-
+		
 		return leaves;
 	}
-
+	
 	public Set<CohortObs> getAllObs(boolean includeVoided) {
 		if (includeVoided && obs != null) {
 			return obs;
 		}
-
+		
 		Set<CohortObs> ret = new HashSet<CohortObs>();
-
+		
 		if (this.obs != null) {
 			for (CohortObs o : this.obs) {
 				if (includeVoided) {
@@ -241,15 +240,15 @@ public class CohortEncounter extends BaseOpenmrsData {
 		}
 		return ret;
 	}
-
+	
 	public void setObs(Set<CohortObs> obs) {
 		this.obs = obs;
 	}
-
+	
 	public Set<CohortObs> getAllObs() {
 		return getAllObs(false);
 	}
-
+	
 	public Set<CohortObs> getObsAtTopLevel(boolean includeVoided) {
 		Set<CohortObs> ret = new HashSet<CohortObs>();
 		for (CohortObs o : getAllObs(includeVoided)) {
@@ -259,50 +258,50 @@ public class CohortEncounter extends BaseOpenmrsData {
 		}
 		return ret;
 	}
-
+	
 	public void addObs(CohortObs observation) {
 		if (obs == null) {
 			obs = new HashSet<>();
 		}
-
+		
 		if (observation != null) {
 			obs.add(observation);
-
+			
 			//Propagate some attributes to the obs and any groupMembers
-
+			
 			// a Deque is a two-ended queue, that lets us add to the end, and fetch from the beginning
 			Deque<CohortObs> obsToUpdate = new ArrayDeque<CohortObs>();
 			obsToUpdate.add(observation);
-
+			
 			//prevent infinite recursion if an obs is its own group member
 			Set<CohortObs> seenIt = new HashSet<CohortObs>();
-
+			
 			while (!obsToUpdate.isEmpty()) {
 				CohortObs o = obsToUpdate.removeFirst();
-
+				
 				//has this obs already been processed?
 				if (o == null || seenIt.contains(o)) {
 					continue;
 				}
 				seenIt.add(o);
-
+				
 				o.setEncounterId(this);
-
+				
 				//if the attribute was already set, preserve it
 				//if not, inherit the values sfrom the encounter
 				if (o.getObsDateTime() == null) {
 					o.setObsDateTime(getEncounterDatetime());
 				}
-
+				
 				//propagate attributes to  all group members as well
 				if (o.getGroupMembers(true) != null) {
 					obsToUpdate.addAll(o.getGroupMembers());
 				}
 			}
-
+			
 		}
 	}
-
+	
 	/**
 	 * Remove the given observation from the list of obs for this Encounter
 	 *
@@ -316,7 +315,7 @@ public class CohortEncounter extends BaseOpenmrsData {
 			obs.remove(observation);
 		}
 	}
-
+	
 	@Deprecated
 	public Person getProvider() {
 		if (encounterProviders == null || encounterProviders.isEmpty()) {
@@ -331,7 +330,7 @@ public class CohortEncounter extends BaseOpenmrsData {
 		}
 		return null;
 	}
-
+	
 	/**
 	 * @param provider The provider to set.
 	 * @deprecated use {@link #setProvider(Person)}
@@ -340,7 +339,7 @@ public class CohortEncounter extends BaseOpenmrsData {
 	public void setProvider(User provider) {
 		setProvider(provider.getPerson());
 	}
-
+	
 	/**
 	 * @param provider The provider to set.
 	 * @should set existing provider for unknown role
@@ -348,11 +347,11 @@ public class CohortEncounter extends BaseOpenmrsData {
 	 */
 	@Deprecated
 	public void setProvider(Person provider) {
-		EncounterRole unknownRole = Context.getEncounterService().getEncounterRoleByUuid(
-				EncounterRole.UNKNOWN_ENCOUNTER_ROLE_UUID);
+		EncounterRole unknownRole = Context.getEncounterService()
+		        .getEncounterRoleByUuid(EncounterRole.UNKNOWN_ENCOUNTER_ROLE_UUID);
 		if (unknownRole == null) {
-			throw new IllegalStateException("No 'Unknown' encounter role with uuid "
-					+ EncounterRole.UNKNOWN_ENCOUNTER_ROLE_UUID + ".");
+			throw new IllegalStateException(
+			        "No 'Unknown' encounter role with uuid " + EncounterRole.UNKNOWN_ENCOUNTER_ROLE_UUID + ".");
 		}
 		Collection<Provider> providers = Context.getProviderService().getProvidersByPerson(provider);
 		if (providers == null || providers.isEmpty()) {
@@ -361,8 +360,3 @@ public class CohortEncounter extends BaseOpenmrsData {
 		setProvider(unknownRole, providers.iterator().next());
 	}
 }
-	
-	
-	
-	
-	

--- a/api/src/main/java/org/openmrs/module/cohort/CohortLeader.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortLeader.java
@@ -20,40 +20,40 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import java.util.Date;
+
 import org.openmrs.BaseOpenmrsData;
 import org.openmrs.Person;
-
-import java.util.Date;
 
 @Entity
 @Table(name = "cohort_leader")
 public class CohortLeader extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_leader_id")
 	private Integer cohortLeaderId;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "person_id")
 	private Person person;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_id")
 	private CohortM cohort;
-
+	
 	@Column(name = "start_date")
 	private Date startDate;
-
+	
 	@Column(name = "end_date")
 	private Date endDate;
-
+	
 	public CohortLeader() {
-
+		
 	}
-
+	
 	public CohortLeader(Person person) {
 		if (person != null) {
 			this.person = person;
@@ -62,53 +62,53 @@ public class CohortLeader extends BaseOpenmrsData {
 			}
 		}
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return cohortLeaderId;
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		this.cohortLeaderId = id;
 	}
-
+	
 	public int getCohortLeaderId() {
 		return cohortLeaderId;
 	}
-
+	
 	public void setCohortLeaderId(int cohortLeaderId) {
 		this.cohortLeaderId = cohortLeaderId;
 	}
-
+	
 	public Person getPerson() {
 		return person;
 	}
-
+	
 	public void setPerson(Person person) {
 		this.person = person;
 	}
-
+	
 	public CohortM getCohort() {
 		return cohort;
 	}
-
+	
 	public void setCohort(CohortM cohort) {
 		this.cohort = cohort;
 	}
-
+	
 	public Date getStartDate() {
 		return startDate;
 	}
-
+	
 	public void setStartDate(Date startDate) {
 		this.startDate = startDate;
 	}
-
+	
 	public Date getEndDate() {
 		return endDate;
 	}
-
+	
 	public void setEndDate(Date endDate) {
 		this.endDate = endDate;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortLeader.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortLeader.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public License,

--- a/api/src/main/java/org/openmrs/module/cohort/CohortM.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortM.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortM.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortM.java
@@ -10,6 +10,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -20,141 +21,141 @@ import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.StringUtils;
 
 @Entity
-@Table(name ="cohort")
+@Table(name = "cohort")
 public class CohortM extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_id")
 	private Integer cohortId;
-
+	
 	private String name;
-
+	
 	private String description;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "location_id")
 	private Location location;
-
+	
 	private Date startDate;
-
+	
 	private Date endDate;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_type_id")
 	private CohortType cohortType;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_program_id")
 	private CohortProgram cohortProgram;
-
+	
 	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
 	private List<CohortAttribute> attributes = new ArrayList<>();
-
+	
 	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
 	private List<CohortLeader> cohortLeaders = new ArrayList<>();
-
+	
 	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
 	private List<CohortMember> cohortMembers = new ArrayList<>();
-
+	
 	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
 	private List<CohortVisit> cohortVisits = new ArrayList<>();
-
+	
 	@Column(name = "is_group_cohort", nullable = false)
 	private Boolean groupCohort;
-
+	
 	public Integer getCohortId() {
 		return cohortId;
 	}
-
+	
 	public void setCohortId(Integer cohortId) {
 		this.cohortId = cohortId;
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		this.name = name;
 	}
-
+	
 	public String getDescription() {
 		return description;
 	}
-
+	
 	public void setDescription(String description) {
 		this.description = description;
 	}
-
+	
 	public Location getLocation() {
 		return location;
 	}
-
+	
 	public void setLocation(Location location) {
 		this.location = location;
 	}
-
+	
 	public Date getStartDate() {
 		return startDate;
 	}
-
+	
 	public void setStartDate(Date startDate) {
 		this.startDate = startDate;
 	}
-
+	
 	public Date getEndDate() {
 		return endDate;
 	}
-
+	
 	public void setEndDate(Date endDate) {
 		this.endDate = endDate;
 	}
-
+	
 	public CohortType getCohortType() {
 		return cohortType;
 	}
-
+	
 	public void setCohortType(CohortType cohortType) {
 		this.cohortType = cohortType;
 	}
-
+	
 	public CohortProgram getCohortProgram() {
 		return cohortProgram;
 	}
-
+	
 	public void setCohortProgram(CohortProgram cohortProgram) {
 		this.cohortProgram = cohortProgram;
 	}
-
+	
 	public void setCohortMembers(List<CohortMember> cohortMembers) {
 		this.cohortMembers = cohortMembers;
 	}
-
+	
 	public List<CohortMember> getCohortMembers() {
 		if (cohortMembers == null) {
 			cohortMembers = new ArrayList<>();
 		}
 		return cohortMembers;
 	}
-
+	
 	public List<CohortVisit> getCohortVisits() {
 		if (cohortVisits == null) {
 			cohortVisits = new ArrayList<>();
 		}
 		return cohortVisits;
 	}
-
+	
 	public void setCohortVisits(List<CohortVisit> cohortVisits) {
 		this.cohortVisits = cohortVisits;
 	}
-
+	
 	public void setCohortLeaders(List<CohortLeader> leaders) {
 		this.cohortLeaders = leaders;
 	}
-
+	
 	public List<CohortMember> getActiveCohortMembers() {
 		List<CohortMember> members = new ArrayList<>();
 		for (CohortMember member : getCohortMembers()) {
@@ -164,14 +165,14 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return members;
 	}
-
+	
 	public List<CohortLeader> getCohortLeaders() {
 		if (cohortLeaders == null) {
 			cohortLeaders = new ArrayList<>();
 		}
 		return cohortLeaders;
 	}
-
+	
 	public List<CohortLeader> getActiveCohortLeaders() {
 		List<CohortLeader> leaders = new ArrayList<>();
 		for (CohortLeader leader : getCohortLeaders()) {
@@ -181,17 +182,17 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return leaders;
 	}
-
+	
 	public List<CohortAttribute> getAttributes() {
 		if (attributes == null) {
 			attributes = new ArrayList<>();
 		}
 		return attributes;
 	}
-
+	
 	public void addCohortLeader(CohortLeader leader) {
 		leader.setCohort(this);
-
+		
 		for (CohortLeader currentLeader : getActiveCohortLeaders()) {
 			if (currentLeader.equals(leader)) {
 				// if we have the same CohortLeader, don't add the new leader
@@ -207,7 +208,7 @@ public class CohortM extends BaseOpenmrsData {
 			cohortLeaders.add(leader);
 		}
 	}
-
+	
 	public CohortMember getMember(String uuid) {
 		if (uuid != null) {
 			for (CohortMember member : getCohortMembers()) {
@@ -218,11 +219,11 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return null;
 	}
-
+	
 	public void setAttributes(List<CohortAttribute> attributes) {
 		this.attributes = attributes;
 	}
-
+	
 	/**
 	 * Returns only the non-voided attributes for this cohort
 	 *
@@ -239,7 +240,7 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return attrs;
 	}
-
+	
 	/**
 	 * Convenience method to add the <code>attribute</code> to this cohort attribute list if the
 	 * attribute doesn't exist already.<br>
@@ -260,7 +261,7 @@ public class CohortM extends BaseOpenmrsData {
 	public void addAttribute(CohortAttribute newAttribute) {
 		newAttribute.setCohort(this);
 		boolean newIsNull = !StringUtils.hasText(newAttribute.getValue());
-
+		
 		for (CohortAttribute currentAttribute : getActiveAttributes()) {
 			if (currentAttribute.equals(newAttribute)) {
 				return; // if we have the same CohortAttributeId, don't add the new attribute
@@ -269,7 +270,7 @@ public class CohortM extends BaseOpenmrsData {
 					// this cohort already has this attribute
 					return;
 				}
-
+				
 				// if the to-be-added attribute isn't already voided itself
 				// and if we have the same type, different value
 				if (!newAttribute.getVoided() || newIsNull) {
@@ -287,7 +288,7 @@ public class CohortM extends BaseOpenmrsData {
 			attributes.add(newAttribute);
 		}
 	}
-
+	
 	/**
 	 * Convenience method to get the <code>attribute</code> from this cohort's attribute list if the
 	 * attribute exists already.
@@ -302,14 +303,14 @@ public class CohortM extends BaseOpenmrsData {
 			attributes.remove(attribute);
 		}
 	}
-
+	
 	/**
-	 * Convenience Method to return the first non-voided cohort attribute matching a cohort
-	 * attribute type. <br>
+	 * Convenience Method to return the first non-voided cohort attribute matching a cohort attribute
+	 * type. <br>
 	 * <br>
 	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given
-	 * {@link CohortAttributeType}, the given {@link CohortAttributeType} is null, or this cohort
-	 * has no attributes.
+	 * {@link CohortAttributeType}, the given {@link CohortAttributeType} is null, or this cohort has no
+	 * attributes.
 	 *
 	 * @param pat the CohortAttributeType to look for (can be a stub, see
 	 *            {@link CohortAttributeType#equals(Object)} for how its compared)
@@ -328,17 +329,16 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return null;
 	}
-
+	
 	/**
-	 * Convenience method to get this cohort's first attribute that has a CohortAttributeType.name
-	 * equal to <code>attributeName</code>.<br>
+	 * Convenience method to get this cohort's first attribute that has a CohortAttributeType.name equal
+	 * to <code>attributeName</code>.<br>
 	 * <br>
-	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type
-	 * name, the given name is null, or this cohort has no attributes.
+	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type name,
+	 * the given name is null, or this cohort has no attributes.
 	 *
 	 * @param attributeName the name string to match on
-	 * @return CohortAttribute whose {@link CohortAttributeType#getName()} matches the given name
-	 * string
+	 * @return CohortAttribute whose {@link CohortAttributeType#getName()} matches the given name string
 	 * @should return cohort attribute based on attributeName
 	 * @should return null if AttributeName is voided
 	 */
@@ -351,16 +351,16 @@ public class CohortM extends BaseOpenmrsData {
 				}
 			}
 		}
-
+		
 		return null;
 	}
-
+	
 	/**
-	 * Convenience method to get this cohort's first attribute that has a CohortAttributeTypeId
-	 * equal to <code>attributeTypeId</code>.<br>
+	 * Convenience method to get this cohort's first attribute that has a CohortAttributeTypeId equal to
+	 * <code>attributeTypeId</code>.<br>
 	 * <br>
-	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type id
-	 * or this cohort has no attributes.<br>
+	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type id or
+	 * this cohort has no attributes.<br>
 	 * <br>
 	 * The given id cannot be null.
 	 *
@@ -377,27 +377,27 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return null;
 	}
-
+	
 	/**
-	 * Convenience method to get all of this cohort's attributes that have a
-	 * CohortAttributeType.name equal to <code>attributeName</code>.
+	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType.name
+	 * equal to <code>attributeName</code>.
 	 *
 	 * @param attributeName
 	 * @should return all CohortAttributes with matching attributeType names
 	 */
 	public List<CohortAttribute> getAttributes(String attributeName) {
 		List<CohortAttribute> ret = new ArrayList<>();
-
+		
 		for (CohortAttribute attribute : getActiveAttributes()) {
 			CohortAttributeType type = attribute.getCohortAttributeType();
 			if (type != null && attributeName.equals(type.getName())) {
 				ret.add(attribute);
 			}
 		}
-
+		
 		return ret;
 	}
-
+	
 	/**
 	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType.id
 	 * equal to <code>attributeTypeId</code>.
@@ -408,19 +408,19 @@ public class CohortM extends BaseOpenmrsData {
 	 */
 	public List<CohortAttribute> getAttributes(Integer attributeTypeId) {
 		List<CohortAttribute> ret = new ArrayList<>();
-
+		
 		for (CohortAttribute attribute : getActiveAttributes()) {
 			if (attributeTypeId.equals(attribute.getCohortAttributeType().getCohortAttributeTypeId())) {
 				ret.add(attribute);
 			}
 		}
-
+		
 		return ret;
 	}
-
+	
 	/**
-	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType
-	 * equal to <code>CohortAttributeType</code>.
+	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType equal
+	 * to <code>CohortAttributeType</code>.
 	 *
 	 * @param CohortAttributeType
 	 */
@@ -433,7 +433,7 @@ public class CohortM extends BaseOpenmrsData {
 		}
 		return ret;
 	}
-
+	
 	/**
 	 * Convenience method for viewing all of the cohort's current attributes
 	 *
@@ -441,16 +441,15 @@ public class CohortM extends BaseOpenmrsData {
 	 */
 	public String printAttributes() {
 		StringBuilder s = new StringBuilder("");
-
+		
 		for (CohortAttribute attribute : getAttributes()) {
 			s.append(attribute.getCohortAttributeType()).append(" : ").append(attribute.getValue()).append(" : voided? ")
-					.append(
-							attribute.getVoided()).append("\n");
+			        .append(attribute.getVoided()).append("\n");
 		}
-
+		
 		return s.toString();
 	}
-
+	
 	/**
 	 * Returns whether this cohort is a group
 	 *
@@ -461,30 +460,27 @@ public class CohortM extends BaseOpenmrsData {
 	public Boolean isGroupCohort() {
 		return groupCohort;
 	}
-
+	
 	public void setGroupCohort(Boolean groupCohort) {
 		this.groupCohort = groupCohort;
 	}
-
+	
 	public Boolean getGroupCohort() {
 		return this.groupCohort;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortId(id);
 	}
-
+	
 	@Override
 	public String toString() {
 		return this.name;
 	}
 }
-	
-	
-	

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMember.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMember.java
@@ -1,8 +1,5 @@
 package org.openmrs.module.cohort;
 
-import org.openmrs.BaseCustomizableData;
-import org.openmrs.Patient;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,44 +9,48 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
 import java.util.Date;
+
+import org.openmrs.BaseCustomizableData;
+import org.openmrs.Patient;
 
 @Entity
 @Table(name = "cohort_member")
 public class CohortMember extends BaseCustomizableData<CohortMemberAttribute> {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_member_id")
 	private Integer cohortMemberId;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "patient_id")
 	private Patient patient;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_id")
 	private CohortM cohort;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_role_id")
 	private CohortRole role;
-
+	
 	@Column(name = "start_date")
 	private Date startDate;
-
+	
 	@Column(name = "end_date")
 	private Date endDate;
-
+	
 	@Column(name = "is_head")
 	private Boolean head;
-
+	
 	public CohortMember() {
-
+		
 	}
-
+	
 	public CohortMember(Patient patient) {
 		if (patient != null) {
 			this.patient = patient;
@@ -58,74 +59,74 @@ public class CohortMember extends BaseCustomizableData<CohortMemberAttribute> {
 			}
 		}
 	}
-
+	
 	public Date getStartDate() {
 		return startDate;
 	}
-
+	
 	public void setStartDate(Date startDate) {
 		this.startDate = startDate;
 	}
-
+	
 	public Date getEndDate() {
 		return endDate;
 	}
-
+	
 	public void setEndDate(Date endDate) {
 		this.endDate = endDate;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortMemberId();
 	}
-
+	
 	@Override
 	public void setId(Integer arg0) {
 		setCohortMemberId(arg0);
 	}
-
+	
 	public Integer getCohortMemberId() {
 		return cohortMemberId;
 	}
-
+	
 	public void setCohortMemberId(Integer cohortMemberId) {
 		this.cohortMemberId = cohortMemberId;
 	}
-
+	
 	public Patient getPatient() {
 		return patient;
 	}
-
+	
 	public void setPatient(Patient patient) {
 		this.patient = patient;
 	}
-
+	
 	public CohortM getCohort() {
 		return cohort;
 	}
-
+	
 	public void setCohort(CohortM cohort) {
 		this.cohort = cohort;
 	}
-
+	
 	public CohortRole getRole() {
 		return role;
 	}
-
+	
 	public void setRole(CohortRole role) {
 		this.role = role;
 	}
-
+	
 	@Deprecated
 	public Boolean isHead() {
 		return head;
 	}
-
+	
 	public void setHead(Boolean head) {
 		this.head = head;
 	}
-
+	
 	public Boolean getHead() {
 		return head;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMember.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMember.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttribute.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttribute.java
@@ -15,18 +15,18 @@ import org.openmrs.attribute.Attribute;
 import org.openmrs.attribute.BaseAttribute;
 
 public class CohortMemberAttribute extends BaseAttribute<CohortMemberAttributeType, CohortMember> implements Attribute<CohortMemberAttributeType, CohortMember> {
-
-    private static final long serialVersionUID = 1L;
-
-    @Getter
-    @Setter
-    private Integer id;
-
+	
+	private static final long serialVersionUID = 1L;
+	
+	@Getter
+	@Setter
+	private Integer id;
+	
 	public CohortMember getCohortMember() {
 		return this.getOwner();
 	}
-
-    public void setCohortMember(CohortMember cohortMember) {
-        this.setOwner(cohortMember);
-    }
+	
+	public void setCohortMember(CohortMember cohortMember) {
+		this.setOwner(cohortMember);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttributeType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMemberAttributeType.java
@@ -14,20 +14,20 @@ import lombok.Setter;
 import org.openmrs.attribute.BaseAttributeType;
 
 public class CohortMemberAttributeType extends BaseAttributeType<CohortMember> {
-
-    private static final long serialVersionUID = 3L;
-
-    @Getter
-    @Setter
-    private Integer cohortMemberAttributeTypeId;
-
-    @Override
-    public Integer getId() {
-        return cohortMemberAttributeTypeId;
-    }
-
-    @Override
-    public void setId(Integer id) {
-        this.cohortMemberAttributeTypeId = id;
-    }
+	
+	private static final long serialVersionUID = 3L;
+	
+	@Getter
+	@Setter
+	private Integer cohortMemberAttributeTypeId;
+	
+	@Override
+	public Integer getId() {
+		return cohortMemberAttributeTypeId;
+	}
+	
+	@Override
+	public void setId(Integer id) {
+		this.cohortMemberAttributeTypeId = id;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMemberVisit.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMemberVisit.java
@@ -16,52 +16,52 @@ import org.openmrs.Visit;
 @Entity
 @Table(name = "cohort_member_visit")
 public class CohortMemberVisit extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_member_visit_id")
 	private Integer cohortMemberVisitId;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "visit_id")
 	private Visit visit;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_visit_id")
 	private CohortVisit cohortVisit;
-
+	
 	@Override
 	public Integer getId() {
 		return this.getCohortMemberVisitId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		this.setCohortMemberVisitId(id);
 	}
-
+	
 	public int getCohortMemberVisitId() {
 		return cohortMemberVisitId;
 	}
-
+	
 	public void setCohortMemberVisitId(int cohortMemberVisitId) {
 		this.cohortMemberVisitId = cohortMemberVisitId;
 	}
-
+	
 	public Visit getVisit() {
 		return visit;
 	}
-
+	
 	public void setVisit(Visit visit) {
 		this.visit = visit;
 	}
-
+	
 	public CohortVisit getCohortVisit() {
 		return cohortVisit;
 	}
-
+	
 	public void setCohortVisit(CohortVisit cohortVisit) {
 		this.cohortVisit = cohortVisit;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortMemberVisit.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortMemberVisit.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortModuleActivator.java
@@ -1,15 +1,11 @@
-/**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.cohort;
 

--- a/api/src/main/java/org/openmrs/module/cohort/CohortModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortModuleActivator.java
@@ -13,7 +13,6 @@
  */
 package org.openmrs.module.cohort;
 
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.BaseModuleActivator;
@@ -24,7 +23,6 @@ import org.openmrs.module.BaseModuleActivator;
 public class CohortModuleActivator extends BaseModuleActivator {
 	
 	protected Log log = LogFactory.getLog(getClass());
-	
 	
 	@Override
 	public void willStart() {

--- a/api/src/main/java/org/openmrs/module/cohort/CohortObs.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortObs.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortObs.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortObs.java
@@ -7,14 +7,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.lang.reflect.Method;
+
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -45,196 +43,196 @@ import org.slf4j.LoggerFactory;
 @Entity
 @Table(name = "cohort_obs")
 public class CohortObs extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	private static final Logger log = LoggerFactory.getLogger(CohortObs.class);
-
+	
 	private static DateFormat TIME_FORMAT = new SimpleDateFormat("HH:mm");
-
+	
 	private static DateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
-
+	
 	private static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "obs_id")
 	private Integer cohortObsId;
-
+	
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "concept_id")
 	protected Concept concept;
-
-	@ManyToOne(optional=false, cascade = CascadeType.ALL)
+	
+	@ManyToOne(optional = false, cascade = CascadeType.ALL)
 	@JoinColumn(name = "encounter_id")
 	private CohortEncounter encounter;
-
+	
 	@ManyToOne
 	@JoinColumn(name = "obs_group_id")
 	protected CohortObs obsGroup;
-
+	
 	@Column(name = "obs_datetime")
 	private Date obsDateTime;
-
+	
 	@OneToMany(cascade = CascadeType.ALL)
 	@BatchSize(size = 25)
 	@OrderBy("cohort_obs_id")
 	protected Set<CohortObs> groupMembers;
-
+	
 	@ManyToOne
 	@JoinColumn(name = "value_coded")
 	protected Concept valueCoded;
-
+	
 	@Transient
 	protected transient ConceptName valueCodedName;
-
+	
 	@Column(name = "value_group_id")
 	protected Integer valueGroupId;
-
+	
 	@Column(name = "value_datetime")
 	protected Date valueDatetime;
-
+	
 	@Column(name = "value_numeric")
 	protected Double valueNumeric;
-
+	
 	@Column(name = "value_modifier", length = 2)
 	protected String valueModifier;
-
+	
 	@Column(name = "value_text", length = 65535)
 	protected String valueText;
-
+	
 	@Column(name = "value_complex")
 	protected String valueComplex;
-
+	
 	@Column(name = "accession_number")
 	protected String accessionNumber;
-
+	
 	protected String comment;
-
+	
 	@Transient
 	protected transient ComplexData complexData;
-
+	
 	public Integer getCohortObsId() {
 		return cohortObsId;
 	}
-
+	
 	public void setCohortObsId(Integer cohortObsId) {
 		this.cohortObsId = cohortObsId;
 	}
-
+	
 	public Concept getConcept() {
 		return concept;
 	}
-
+	
 	public void setConcept(Concept concept) {
 		this.concept = concept;
 	}
-
+	
 	public CohortEncounter getEncounterId() {
 		return encounter;
 	}
-
+	
 	public void setEncounterId(CohortEncounter encounterId) {
 		this.encounter = encounterId;
 	}
-
+	
 	public Date getObsDateTime() {
 		return obsDateTime;
 	}
-
+	
 	public void setObsDateTime(Date obsDateTime) {
 		this.obsDateTime = obsDateTime;
 	}
-
+	
 	public CohortObs getObsGroup() {
 		return obsGroup;
 	}
-
+	
 	public void setObsGroup(CohortObs obsGroup) {
 		this.obsGroup = obsGroup;
 	}
-
+	
 	public String getComment() {
 		return comment;
 	}
-
+	
 	public void setComment(String comment) {
 		this.comment = comment;
 	}
-
+	
 	public Concept getValueCoded() {
 		return valueCoded;
 	}
-
+	
 	public void setValueCoded(Concept valueCoded) {
 		this.valueCoded = valueCoded;
 	}
-
+	
 	public ConceptName getValueCodedName() {
 		return valueCodedName;
 	}
-
+	
 	public void setValueCodedName(ConceptName valueCodedName) {
 		this.valueCodedName = valueCodedName;
 	}
-
+	
 	public Integer getValueGroupId() {
 		return valueGroupId;
 	}
-
+	
 	public void setValueGroupId(Integer valueGroupId) {
 		this.valueGroupId = valueGroupId;
 	}
-
+	
 	public Date getValueDatetime() {
 		return valueDatetime;
 	}
-
+	
 	public void setValueDatetime(Date valueDatetime) {
 		this.valueDatetime = valueDatetime;
 	}
-
+	
 	public Double getValueNumeric() {
 		return valueNumeric;
 	}
-
+	
 	public void setValueNumeric(Double valueNumeric) {
 		this.valueNumeric = valueNumeric;
 	}
-
+	
 	public String getValueModifier() {
 		return valueModifier;
 	}
-
+	
 	public void setValueModifier(String valueModifier) {
 		this.valueModifier = valueModifier;
 	}
-
+	
 	public String getValueText() {
 		return valueText;
 	}
-
+	
 	public void setValueText(String valueText) {
 		this.valueText = valueText;
 	}
-
+	
 	public ComplexData getComplexData() {
 		return complexData;
 	}
-
+	
 	public void setComplexData(ComplexData complexData) {
 		this.complexData = complexData;
 	}
-
+	
 	public String getValueComplex() {
 		return this.valueComplex;
 	}
-
+	
 	/**
-	 * Set the value for the ComplexData. This method is used by the ComplexObsHandler. The
-	 * valueComplex has two parts separated by a bar '|' character: part A) the title; and part B)
-	 * the URI. The title is the readable description of the valueComplex that is returned by
-	 * Obs.getValueAsString(). The URI is the location where the ComplexData is stored.
+	 * Set the value for the ComplexData. This method is used by the ComplexObsHandler. The valueComplex
+	 * has two parts separated by a bar '|' character: part A) the title; and part B) the URI. The title
+	 * is the readable description of the valueComplex that is returned by Obs.getValueAsString(). The
+	 * URI is the location where the ComplexData is stored.
 	 *
 	 * @param valueComplex readable title and URI for the location of the ComplexData binary object.
 	 * @since 1.5
@@ -242,46 +240,46 @@ public class CohortObs extends BaseOpenmrsData {
 	public void setValueComplex(String valueComplex) {
 		this.valueComplex = valueComplex;
 	}
-
+	
 	public String getAccessionNumber() {
 		return accessionNumber;
 	}
-
+	
 	public void setAccessionNumber(String accessionNumber) {
 		this.accessionNumber = accessionNumber;
 	}
-
+	
 	public void setGroupMembers(Set<CohortObs> groupMembers) {
 		this.groupMembers = groupMembers;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortObsId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortObsId(id);
 	}
-
+	
 	public boolean hasGroupMembers(boolean includeVoided) {
 		// ! symbol used because if it's not empty, we want true
 		return !org.springframework.util.CollectionUtils.isEmpty(getGroupMembers(includeVoided));
 	}
-
+	
 	public boolean hasGroupMembers() {
 		return hasGroupMembers(false);
 	}
-
+	
 	public Set<CohortObs> getGroupMembers() {
 		return getGroupMembers(false); //same as just returning groupMembers
 	}
-
+	
 	public boolean isObsGrouping() {
 		return hasGroupMembers(true);
 	}
-
+	
 	public Set<CohortObs> getGroupMembers(boolean includeVoided) {
 		if (includeVoided) {
 			//just return all group members
@@ -301,7 +299,7 @@ public class CohortObs extends BaseOpenmrsData {
 		}
 		return nonVoided;
 	}
-
+	
 	public String getValueAsString(Locale locale) {
 		// formatting for the return of numbers of type double
 		NumberFormat nf = NumberFormat.getNumberInstance(locale);
@@ -326,7 +324,7 @@ public class CohortObs extends BaseOpenmrsData {
 						} else {
 							return "";
 						}
-
+						
 					}
 				}
 			} else if ("NM".equals(abbrev) || "SN".equals(abbrev)) {
@@ -361,7 +359,7 @@ public class CohortObs extends BaseOpenmrsData {
 				}
 			}
 		}
-
+		
 		// if the datatype is 'unknown', default to just returning what is not null
 		if (getValueNumeric() != null) {
 			return df.format(getValueNumeric());
@@ -390,7 +388,7 @@ public class CohortObs extends BaseOpenmrsData {
 			}
 			return sb.toString();
 		}
-
+		
 		// returns the title portion of the valueComplex
 		// which is everything before the first bar '|' character.
 		if (getValueComplex() != null) {
@@ -401,12 +399,12 @@ public class CohortObs extends BaseOpenmrsData {
 				}
 			}
 		}
-
+		
 		return "";
 	}
-
+	
 	public Boolean getValueAsBoolean() {
-
+		
 		if (getValueCoded() != null) {
 			if (getValueCoded().equals(Context.getConceptService().getTrueConcept())) {
 				return Boolean.TRUE;
@@ -423,7 +421,7 @@ public class CohortObs extends BaseOpenmrsData {
 		//returning null is preferred to defaulting to false to support validation of user input is from a form
 		return null;
 	}
-
+	
 	/**
 	 * Returns the boolean value if the concept of this obs is of boolean datatype
 	 *
@@ -436,15 +434,15 @@ public class CohortObs extends BaseOpenmrsData {
 			Concept trueConcept = Context.getConceptService().getTrueConcept();
 			return trueConcept != null && valueCoded.getId().equals(trueConcept.getId());
 		}
-
+		
 		return null;
 	}
-
+	
 	public void setValueAsString(String s) throws ParseException {
 		if (log.isDebugEnabled()) {
 			log.debug("getConcept() == " + getConcept());
 		}
-
+		
 		if (getConcept() != null && !StringUtils.isBlank(s)) {
 			String abbrev = getConcept().getDatatype().getHl7Abbreviation();
 			if ("BIT".equals(abbrev)) {
@@ -464,12 +462,12 @@ public class CohortObs extends BaseOpenmrsData {
 			} else {
 				throw new RuntimeException("Don't know how to handle " + abbrev);
 			}
-
+			
 		} else {
 			throw new RuntimeException("concept is null for " + this);
 		}
 	}
-
+	
 	@Deprecated
 	public Map<Locale, String> getValueAsString() {
 		Map<Locale, String> localeMap = new HashMap<Locale, String>();
@@ -479,18 +477,13 @@ public class CohortObs extends BaseOpenmrsData {
 		}
 		return localeMap;
 	}
-
+	
 	public void setValueBoolean(Boolean valueBoolean) {
 		if (valueBoolean != null && getConcept() != null && getConcept().getDatatype().isBoolean()) {
-			setValueCoded(valueBoolean.booleanValue() ? Context.getConceptService().getTrueConcept() : Context
-					.getConceptService().getFalseConcept());
+			setValueCoded(valueBoolean.booleanValue() ? Context.getConceptService().getTrueConcept()
+			        : Context.getConceptService().getFalseConcept());
 		} else if (valueBoolean == null) {
 			setValueCoded(null);
 		}
 	}
 }
-	
-	
-	
-	
-	

--- a/api/src/main/java/org/openmrs/module/cohort/CohortProgram.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortProgram.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.Column;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortProgram.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortProgram.java
@@ -12,48 +12,48 @@ import org.openmrs.BaseOpenmrsData;
 @Entity
 @Table(name = "cohort_program")
 public class CohortProgram extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_program_id")
 	private int cohortProgramId;
-
+	
 	private String name;
-
+	
 	private String description;
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortProgramId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortProgramId(id);
 	}
-
+	
 	public int getCohortProgramId() {
 		return cohortProgramId;
 	}
-
+	
 	public void setCohortProgramId(int cohortProgramId) {
 		this.cohortProgramId = cohortProgramId;
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		this.name = name;
 	}
-
+	
 	public String getDescription() {
 		return description;
 	}
-
+	
 	public void setDescription(String description) {
 		this.description = description;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortRole.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortRole.java
@@ -15,54 +15,54 @@ import org.openmrs.BaseOpenmrsData;
 @Entity
 @Table(name = "cohort_role")
 public class CohortRole extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_role_id")
 	private Integer cohortRoleId;
-
+	
 	private String name;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "cohort_type_id")
 	private CohortType cohortType;
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortRoleId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortRoleId(id);
 	}
-
+	
 	public Integer getCohortRoleId() {
 		return cohortRoleId;
 	}
-
+	
 	public void setCohortRoleId(int cohortRoleId) {
 		this.cohortRoleId = cohortRoleId;
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		this.name = name;
 	}
-
+	
 	public CohortType getCohortType() {
 		return cohortType;
 	}
-
+	
 	public void setCohortType(CohortType cohortType) {
 		this.cohortType = cohortType;
 	}
-
+	
 	@Override
 	public String toString() {
 		return this.name;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortRole.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortRole.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortType.java
@@ -12,48 +12,48 @@ import org.openmrs.BaseOpenmrsData;
 @Entity
 @Table(name = "cohort_type")
 public class CohortType extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_type_id")
 	private int cohortTypeId;
-
+	
 	private String name;
-
+	
 	private String description;
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortTypeId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortTypeId(id);
 	}
-
+	
 	public int getCohortTypeId() {
 		return cohortTypeId;
 	}
-
+	
 	public void setCohortTypeId(int cohortTypeId) {
 		this.cohortTypeId = cohortTypeId;
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		this.name = name;
 	}
-
+	
 	public String getDescription() {
 		return description;
 	}
-
+	
 	public void setDescription(String description) {
 		this.description = description;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortType.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.Column;

--- a/api/src/main/java/org/openmrs/module/cohort/CohortVisit.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortVisit.java
@@ -11,8 +11,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
-import java.util.Date;
+
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.openmrs.BaseOpenmrsData;
@@ -24,106 +25,106 @@ import org.openmrs.api.handler.VoidHandler;
 @Entity
 @Table(name = "cohort_visit")
 public class CohortVisit extends BaseOpenmrsData {
-
+	
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "cohort_visit_id")
 	private Integer cohortVisitId;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL, optional = false)
 	@JoinColumn(name = "cohort_id")
 	private CohortM cohort;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL, optional = false)
 	@JoinColumn(name = "visit_type_id")
 	private VisitType visitType;
-
+	
 	@ManyToOne(cascade = CascadeType.ALL, optional = false)
 	@JoinColumn(name = "location_id")
 	private Location location;
-
+	
 	@Column(name = "start_date")
 	private Date startDate;
-
+	
 	@Column(name = "end_Date")
 	private Date endDate;
-
+	
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "cohortVisit")
 	@OrderBy("cohort_visit_id")
 	@DisableHandlers(handlerTypes = { VoidHandler.class })
 	private List<CohortMemberVisit> cohortMemberVisits = new ArrayList<CohortMemberVisit>();
-
+	
 	public Integer getCohortVisitId() {
 		return cohortVisitId;
 	}
-
+	
 	public void setCohortVisitId(Integer cohortVisitId) {
 		this.cohortVisitId = cohortVisitId;
 	}
-
+	
 	public CohortM getCohort() {
 		return cohort;
 	}
-
+	
 	public void setCohort(CohortM cohort) {
 		this.cohort = cohort;
 	}
-
+	
 	public VisitType getVisitType() {
 		return visitType;
 	}
-
+	
 	public void setVisitType(VisitType visitType) {
 		this.visitType = visitType;
 	}
-
+	
 	public Location getLocation() {
 		return location;
 	}
-
+	
 	public void setLocation(Location location) {
 		this.location = location;
 	}
-
+	
 	public Date getStartDate() {
 		return startDate;
 	}
-
+	
 	public void setStartDate(Date startDate) {
 		this.startDate = startDate;
 	}
-
+	
 	public Date getEndDate() {
 		return endDate;
 	}
-
+	
 	public void setEndDate(Date endDate) {
 		this.endDate = endDate;
 	}
-
+	
 	@Override
 	public Integer getId() {
 		return getCohortVisitId();
 	}
-
+	
 	@Override
 	public void setId(Integer id) {
 		setCohortVisitId(id);
 	}
-
+	
 	public void addMemberVisit(CohortMemberVisit cohortMemberVisit) {
 		this.cohortMemberVisits.add(cohortMemberVisit);
 	}
-
+	
 	public List<CohortMemberVisit> getCohortMemberVisits() {
 		if (cohortMemberVisits == null) {
 			cohortMemberVisits = new ArrayList<>();
 		}
 		return this.cohortMemberVisits;
 	}
-
+	
 	public void setCohortMemberVisits(List<CohortMemberVisit> cohortMemberVisits) {
 		this.cohortMemberVisits = cohortMemberVisits;
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/CohortVisit.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortVisit.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort;
 
 import javax.persistence.CascadeType;

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
@@ -9,30 +9,32 @@
  */
 package org.openmrs.module.cohort.api;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.cohort.CohortMemberAttribute;
 import org.openmrs.module.cohort.CohortMemberAttributeType;
 
-import javax.validation.constraints.NotNull;
-import java.util.List;
-
 public interface CohortMemberService extends OpenmrsService {
-
-    CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
-
-    List<CohortMemberAttributeType> getAllCohortMemberAttributeTypes();
-
-    CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
-
-    CohortMemberAttributeType deleteCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason);
-
-    void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
-
-    CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
-
-    List<CohortMemberAttribute> getCohortMemberAttributeByTypeUuid(@NotNull String attributeTypeUuid);
-
-    CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
-
-    void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
+	
+	CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
+	
+	List<CohortMemberAttributeType> getAllCohortMemberAttributeTypes();
+	
+	CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
+	
+	CohortMemberAttributeType deleteCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType,
+	        String voidReason);
+	
+	void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
+	
+	CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
+	
+	List<CohortMemberAttribute> getCohortMemberAttributeByTypeUuid(@NotNull String attributeTypeUuid);
+	
+	CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
+	
+	void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
@@ -13,6 +13,11 @@
  */
 package org.openmrs.module.cohort.api;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 import org.openmrs.Concept;
 import org.openmrs.EncounterType;
 import org.openmrs.Form;
@@ -33,15 +38,9 @@ import org.openmrs.module.cohort.CohortType;
 import org.openmrs.module.cohort.CohortVisit;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 /**
- * This service exposes module's core functionality. It is a Spring managed bean which is configured in moduleApplicationContext.xml.
- *
- * It can be accessed only via Context:<br>
+ * This service exposes module's core functionality. It is a Spring managed bean which is configured
+ * in moduleApplicationContext.xml. It can be accessed only via Context:<br>
  * <code>
  * Context.getService(cohortService.class).someMethod();
  * </code>
@@ -50,173 +49,171 @@ import java.util.Map;
  */
 @Transactional
 public interface CohortService extends OpenmrsService {
-
+	
 	CohortM getCohortById(Integer id);
-
+	
 	CohortM getCohortByUuid(String uuid);
-
+	
 	CohortM getCohortByName(String name);
-
+	
 	List<CohortM> getAllCohorts();
-
+	
 	List<CohortM> findCohortsMatching(String nameMatching, Map<String, String> attributes, CohortType cohortType);
-
+	
 	CohortM saveCohort(CohortM cohort);
-
+	
 	void purgeCohort(CohortM cohort);
-
+	
 	CohortM getCohort(Integer locationId, Integer programId, Integer typeId);
-
+	
 	CohortMember getCohortMemberByUuid(String uuid);
-
+	
 	List<CohortMember> findCohortMemberByName(String name);
-
+	
 	List<CohortMember> findCohortMembersByCohort(Integer cohortId);
-
+	
 	CohortMember getCohortMemberById(Integer id);
-
+	
 	List<CohortMember> getCohortMembersByCohortId(Integer id);
-
+	
 	List<CohortMember> getCohortMembersByCohortRoleId(Integer id);
-
+	
 	List<CohortMember> getAllHeadCohortMembers();
-
+	
 	CohortMember saveCohortMember(CohortMember cohortmember);
-
+	
 	List<CohortMember> findCohortMembersByPatient(int patientId);
-
+	
 	CohortAttributeType getCohortAttributeType(Integer id);
-
+	
 	List<CohortAttributeType> getAllCohortAttributeTypes();
-
+	
 	CohortAttributeType getCohortAttributeTypeByName(String attribute_type_name);
-
+	
 	CohortAttributeType getCohortAttributeTypeByUuid(String uuid);
-
+	
 	CohortAttributeType saveCohort(CohortAttributeType a);
-
+	
 	void purgeCohortAttributes(CohortAttributeType attributes);
-
+	
 	CohortAttribute getCohortAttributeByUuid(String uuid);
-
+	
 	CohortAttribute getCohortAttributeById(Integer id);
-
+	
 	CohortAttribute saveCohortAttribute(CohortAttribute att);
-
+	
 	void purgeCohortAtt(CohortAttribute att);
-
+	
 	List<CohortAttribute> findCohortAttributes(Integer cohortId, Integer attributeTypeId);
-
+	
 	CohortRole getCohortRoleByUuid(String uuid);
-
+	
 	CohortRole getCohortRoleByName(String name);
-
+	
 	CohortRole getCohortRoleById(Integer id);
-
+	
 	List<CohortRole> getAllCohortRoles();
-
+	
 	CohortRole saveCohortRole(CohortRole cohort);
-
+	
 	void purgeCohortRole(CohortRole crole);
-
+	
 	CohortType getCohortTypeById(Integer id);
-
+	
 	CohortType getCohortTypeByUuid(String uuid);
-
+	
 	CohortType getCohortTypeByName(String name);
-
+	
 	List<CohortType> getAllCohortTypes();
-
+	
 	CohortType saveCohort(CohortType cohort);
-
+	
 	void purgeCohortType(CohortType type);
-
+	
 	CohortProgram getCohortProgramByUuid(String uuid);
-
+	
 	CohortProgram getCohortProgramById(Integer id);
-
+	
 	CohortProgram getCohortProgramByName(String name);
-
+	
 	List<CohortProgram> getAllCohortPrograms();
-
+	
 	CohortProgram saveCohortProgram(CohortProgram cohort);
-
+	
 	void purgeCohortProgram(CohortProgram cvisit);
-
+	
 	CohortVisit getCohortVisitById(Integer id);
-
+	
 	List<CohortVisit> getCohortVisitByType(Integer visitType);
-
+	
 	CohortVisit getCohortVisitByUuid(String uuid);
-
+	
 	CohortVisit saveCohortVisit(CohortVisit cvisit);
-
+	
 	List<CohortVisit> getCohortVisitsByLocation(Integer id);
-
+	
 	List<CohortVisit> getCohortVisitsByDate(Date startDate, Date endDate);
-
+	
 	void purgeCohortVisit(CohortVisit cvisit);
-
+	
 	CohortEncounter getCohortEncounterByUuid(String uuid);
-
+	
 	CohortEncounter getCohortEncounterById(Integer id);
-
+	
 	List<CohortEncounter> filterEncountersByViewPermissions(List<CohortEncounter> encounters, User user);
-
+	
 	List<CohortEncounter> findCohortEncounter(String cohort, String location);
-
-	List<CohortEncounter> getEncounters(CohortM who, Location loc,
-			Date fromDate, Date toDate, Collection<Form> enteredViaForms,
-			Collection<EncounterType> encounterTypes, boolean includeVoided);
-
+	
 	List<CohortEncounter> getEncounters(CohortM who, Location loc, Date fromDate, Date toDate,
-			Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<User> providers,
-			boolean includeVoided);
-
+	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, boolean includeVoided);
+	
+	List<CohortEncounter> getEncounters(CohortM who, Location loc, Date fromDate, Date toDate,
+	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<User> providers,
+	        boolean includeVoided);
+	
 	List<CohortEncounter> getEncountersByCohort(String query, Integer cohortId, boolean includeVoided);
-
+	
 	CohortEncounter saveCohortEncounter(CohortEncounter cencounters);
-
+	
 	void purgeCohortEncounter(CohortEncounter cencounters);
-
+	
 	CohortObs getCohortObsByUuid(String uuid);
-
+	
 	CohortObs getCohortObsById(Integer id);
-
-	List<CohortObs> getObservations(List<CohortM> whom,
-			List<CohortEncounter> encounters, List<Concept> questions,
-			List<Concept> answers, List<Location> locations, List<String> sort,
-			Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs);
-
+	
+	List<CohortObs> getObservations(List<CohortM> whom, List<CohortEncounter> encounters, List<Concept> questions,
+	        List<Concept> answers, List<Location> locations, List<String> sort, Integer mostRecentN, Integer obsGroupId,
+	        Date fromDate, Date toDate, boolean includeVoidedObs);
+	
 	List<CohortObs> getObservationsByCohortAndConcept(CohortM who, Concept question);
-
+	
 	CohortObs saveCohortObs(CohortObs cobs);
-
+	
 	CohortObs voidObs(CohortObs obs, String reason);
-
+	
 	List<CohortObs> getCohortObsByEncounterId(Integer id);
-
+	
 	void purgeCohortObs(CohortObs cobs);
-
+	
 	Long getCount(String name);
-
+	
 	CohortLeader getCohortLeaderByUuid(String uuid);
-
+	
 	CohortLeader getCohortLeaderById(Integer id);
-
+	
 	List<CohortLeader> getCohortLeadersByCohortId(Integer id);
-
+	
 	CohortLeader saveCohortLeader(CohortLeader cohortLeader);
-
+	
 	CohortLeader voidCohortLeader(CohortLeader cohortLeader, String reason);
-
+	
 	void purgeCohortLeader(CohortLeader cohortLeader);
-
+	
 	CohortMemberVisit getCohortMemberVisitByUuid(String uuid);
-
+	
 	CohortMemberVisit saveCohortMemberVisit(CohortMemberVisit cohortMemberVisit);
-
+	
 	List<CohortAttribute> getCohortAttributesByAttributeType(Integer attributeId);
-
+	
 	List<CohortM> getCohortsByLocationId(int locationId);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
@@ -1,15 +1,11 @@
-/**
- * The contents of this file are subject to the OpenMRS License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.cohort.api;
 

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/CohortDAO.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/CohortDAO.java
@@ -1,15 +1,11 @@
-/**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.cohort.api.db;
 

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/CohortDAO.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/CohortDAO.java
@@ -23,8 +23,6 @@ import org.openmrs.module.cohort.CohortEncounter;
 import org.openmrs.module.cohort.CohortLeader;
 import org.openmrs.module.cohort.CohortM;
 import org.openmrs.module.cohort.CohortMember;
-import org.openmrs.module.cohort.CohortMemberAttribute;
-import org.openmrs.module.cohort.CohortMemberAttributeType;
 import org.openmrs.module.cohort.CohortMemberVisit;
 import org.openmrs.module.cohort.CohortObs;
 import org.openmrs.module.cohort.CohortProgram;
@@ -33,142 +31,229 @@ import org.openmrs.module.cohort.CohortType;
 import org.openmrs.module.cohort.CohortVisit;
 import org.openmrs.module.cohort.api.CohortService;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * Database methods for {@link CohortService}.
  */
 public interface CohortDAO {
- 
+	
 	CohortAttribute getCohortAttributeById(Integer id);
+	
 	CohortAttribute getCohortAttributeByUuid(String uuid);
+	
 	CohortAttribute saveCohortAttributes(CohortAttribute att);
+	
 	List<CohortAttribute> findCohortAttributes(Integer cohortId, Integer attributeTypeId);
- 
+	
 	CohortAttributeType getCohortAttributeTypeById(Integer id);
+	
 	CohortAttributeType getCohortAttributeTypeByUuid(String uuid);
+	
 	CohortAttributeType getCohortAttributeTypeUuid(String uuid);
+	
 	CohortAttributeType getCohortAttributes(Integer cohort_attribute_type_id);
+	
 	CohortAttributeType saveCohortAttributes(CohortAttributeType attributes);
 	
 	CohortEncounter getCohortEncounter(Integer id);
+	
 	CohortEncounter getCohortEncounterById(Integer id);
+	
 	CohortEncounter getCohortEncounterByUuid(String uuid);
+	
 	CohortEncounter getCohortEncounterUuid(String uuid);
+	
 	CohortEncounter saveCohortEncounters(CohortEncounter cencounters);
 	
 	CohortM getCohortByName(String name);
+	
 	CohortM getCohortMById(Integer id);
+	
 	CohortM getCohortMByUuid(String uuid);
+	
 	CohortM getCohortUuid(String uuid);
+	
 	CohortM saveCohort(CohortM cohort);
+	
 	CohortM getCohort(Integer locationId, Integer ProgramId, Integer TypeId);
- 
+	
 	CohortMember getCohortMemUuid(String uuid);
+	
 	CohortMember getCohortMemberById(Integer id);
+	
 	CohortMember getCohortMemberByUuid(String uuid);
+	
 	CohortMember saveCPatient(CohortMember cohort);
 	
 	CohortObs getCohortObsById(Integer id);
+	
 	CohortObs getCohortObsByUuid(String uuid);
+	
 	CohortObs getCohortObsUuid(String uuid);
+	
 	CohortObs saveCohortObs(CohortObs cobs);
+	
 	List<CohortObs> getCohortObsByEncounterId(Integer id);
+	
 	CohortObs saveObs(CohortObs obs);
 	
 	CohortProgram getCohortProgramById(Integer id);
+	
 	CohortProgram getCohortProgramByUuid(String uuid);
+	
 	CohortProgram getCohortProgramUuid(String uuid);
+	
 	CohortProgram saveCohortProgram(CohortProgram cohort);
 	
 	CohortRole getCohortRoleById(Integer id);
+	
 	CohortRole getCohortRoleByUuid(String uuid);
+	
 	CohortRole getCohortRoleUuid(String uuid);
+	
 	CohortRole saveCohortRole(CohortRole cohort);
+	
 	List<CohortRole> getAllCohortRoles();
+	
 	CohortRole getCohortRoleByName(String name);
+	
 	void deleteCohortRoleById(Integer id);
 	
 	CohortType getCohortType(Integer id);
+	
 	CohortType getCohortTypeById(Integer id);
+	
 	CohortType getCohortTypeByUuid(String uuid);
+	
 	CohortType getCohortTypeByName(String name);
+	
 	CohortType saveCohortType(CohortType cohorttype);
 	
 	CohortVisit getCohortVisitById(Integer id);
+	
 	CohortVisit getCohortVisitByUuid(String uuid);
+	
 	List<CohortVisit> getCohortVisitsByLocationId(Integer id);
+	
 	List<CohortVisit> getCohortVisitsByDate(Date startDate, Date endDate);
+	
 	CohortVisit saveCohortVisit(CohortVisit cvisit);
 	
 	CohortAttribute getCohortAttribute(Integer id);
+	
 	List<CohortAttribute> getCohortAttributesByAttributeType(Integer attributeTypeId);
+	
 	List<CohortAttribute> findCohortAttribute(String name);
-
+	
 	CohortAttributeType findCohortAttributeType(Integer id);
+	
 	List<CohortAttributeType> getAllCohortAttributes();
+	
 	CohortAttributeType findCohortAttributes(String attribute_type_name);
 	
 	CohortEncounter findCohortEncounter(Integer id);
+	
 	List<CohortEncounter> findCohortEncounter(String cohort, String location);
+	
 	List<CohortEncounter> findCohortEncounters();
+	
 	List<CohortEncounter> findCohortEncounters(String name);
+	
 	List<CohortEncounter> getEncounters(EncounterSearchCriteria searchCriteria);
-	List<CohortEncounter> getEncounters(String query, Integer cohortId, Integer start, Integer length, boolean includeVoided);
+	
+	List<CohortEncounter> getEncounters(String query, Integer cohortId, Integer start, Integer length,
+	        boolean includeVoided);
 	
 	List<CohortM> findCohorts();
+	
 	List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType type);
+	
 	CohortM getCohort(Integer id);
+	
 	List<CohortM> getCohortsByLocationId(Integer id);
+	
 	List<CohortM> getCohortByCohortTypeId(Integer id);
+	
 	List<CohortM> getCohortByCohortProgramId(Integer id);
- 
+	
 	List<CohortMember> findCohortMember();
+	
 	List<CohortMember> findCohortMember(String name);
-	List<CohortMember> findCohortMembersByCohortId (Integer cohortId);
+	
+	List<CohortMember> findCohortMembersByCohortId(Integer cohortId);
+	
 	List<CohortMember> getCohortMembersByCohortId(Integer id);
+	
 	CohortMember getCohortMember(Integer id);
+	
 	List<CohortMember> getAllHeadCohortMembers();
+	
 	List<CohortMember> getCohortMembersByCohortRoleId(Integer id);
+	
 	List<CohortMember> getCohortMembersByPatientId(int patientId);
- 
+	
 	List<CohortObs> findCohortObs();
+	
 	CohortObs findCohortObs(Integer id);
 	
 	List<CohortProgram> findCohortProg();
+	
 	CohortProgram findCohortProgram(Integer id);
+	
 	CohortProgram findCohortProgram(String name);
 	
 	CohortRole findCohortRole(Integer id);
+	
 	List<CohortRole> findCohortRole(String cohort_name);
+	
 	List<CohortRole> findCohortRoles(String name);
+	
 	List<CohortRole> findRoles(String name);
 	
 	List<CohortType> findCohortType();
+	
 	CohortType findCohortType(Integer id);
+	
 	List<CohortType> findCohortType(String cohort_name);
+	
 	List<CohortType> getAllCohortTypes();
 	
 	List<CohortVisit> findCohortVisitByVisitType(Integer visitType);
+	
 	CohortVisit findCohortVisit(Integer id);
+	
 	List<CohortVisit> findCohortVisit(String name);
- 
-    CohortLeader getCohortLeaderByUuid(String uuid);
-    CohortLeader getCohortLeaderById(Integer id);
-    List<CohortLeader> getCohortLeadersByCohortId(Integer id);
+	
+	CohortLeader getCohortLeaderByUuid(String uuid);
+	
+	CohortLeader getCohortLeaderById(Integer id);
+	
+	List<CohortLeader> getCohortLeadersByCohortId(Integer id);
+	
 	CohortLeader saveCohortLeader(CohortLeader cohortLeader);
-    CohortMemberVisit getCohortMemberVisitByUuid(String uuid);
+	
+	CohortMemberVisit getCohortMemberVisitByUuid(String uuid);
+	
 	CohortMemberVisit saveCohortMemberVisit(CohortMemberVisit cohortMemberVisit);
-
+	
 	Long getCount(String name);
+	
 	void purgeCohort(CohortM cohort);
+	
 	void purgeCohortAtt(CohortAttribute att);
+	
 	void purgeCohortAttributes(CohortAttributeType attributes);
+	
 	void purgeCohortEncounters(CohortEncounter cencounters);
+	
 	void purgeCohortObs(CohortObs cobs);
+	
 	void purgeCohortProgram(CohortProgram cvisit);
+	
 	void purgeCohortRole(CohortRole crole);
+	
 	void purgeCohortType(CohortType cohort);
-	void purgeCohortVisit(CohortVisit cvisit); 
-    void purgeCohortLeader(CohortLeader cohortLeader);
+	
+	void purgeCohortVisit(CohortVisit cvisit);
+	
+	void purgeCohortLeader(CohortLeader cohortLeader);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/CohortMemberAttributeDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/CohortMemberAttributeDao.java
@@ -9,27 +9,28 @@
  */
 package org.openmrs.module.cohort.api.db;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
 import org.openmrs.annotation.Authorized;
 import org.openmrs.module.cohort.CohortMemberAttribute;
 import org.openmrs.util.PrivilegeConstants;
 
-import javax.validation.constraints.NotNull;
-import java.util.List;
-
 public interface CohortMemberAttributeDao {
-
-    @Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
-    CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
-
-    @Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
-    List<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(@NotNull String attributeTypeUuid);
-
-    @Authorized(PrivilegeConstants.ADD_COHORTS)
-    CohortMemberAttribute saveCohortMemberAttribute(@NotNull CohortMemberAttribute cohortMemberAttribute);
-
-    @Authorized(PrivilegeConstants.DELETE_COHORTS)
-    CohortMemberAttribute deleteCohortMemberAttribute (@NotNull String uuid);
-
-    @Authorized(PrivilegeConstants.PURGE_COHORTS)
-    void purgeCohortMemberAttribute (CohortMemberAttribute cohortMemberAttribute);
+	
+	@Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
+	CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
+	
+	@Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
+	List<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(@NotNull String attributeTypeUuid);
+	
+	@Authorized(PrivilegeConstants.ADD_COHORTS)
+	CohortMemberAttribute saveCohortMemberAttribute(@NotNull CohortMemberAttribute cohortMemberAttribute);
+	
+	@Authorized(PrivilegeConstants.DELETE_COHORTS)
+	CohortMemberAttribute deleteCohortMemberAttribute(@NotNull String uuid);
+	
+	@Authorized(PrivilegeConstants.PURGE_COHORTS)
+	void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/CohortMemberAttributeTypeDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/CohortMemberAttributeTypeDao.java
@@ -9,27 +9,29 @@
  */
 package org.openmrs.module.cohort.api.db;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
 import org.openmrs.annotation.Authorized;
 import org.openmrs.module.cohort.CohortMemberAttributeType;
 import org.openmrs.util.PrivilegeConstants;
 
-import javax.validation.constraints.NotNull;
-import java.util.List;
-
 public interface CohortMemberAttributeTypeDao {
-
-    @Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
-    CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
-
-    @Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
-    List<CohortMemberAttributeType> getCohortMemberAttributeTypes();
-
-    @Authorized(PrivilegeConstants.ADD_COHORTS)
-    CohortMemberAttributeType createCohortMemberAttributeType(@NotNull CohortMemberAttributeType cohortMemberAttributeType);
-
-    @Authorized(PrivilegeConstants.DELETE_COHORTS)
-    CohortMemberAttributeType deleteCohortMemberAttributeType (@NotNull CohortMemberAttributeType cohortMemberAttributeType, String voidReason);
-
-    @Authorized(PrivilegeConstants.PURGE_COHORTS)
-    void purgeCohortMemberAttribute (CohortMemberAttributeType cohortMemberAttributeType);
+	
+	@Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
+	CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
+	
+	@Authorized(PrivilegeConstants.GET_PATIENT_COHORTS)
+	List<CohortMemberAttributeType> getCohortMemberAttributeTypes();
+	
+	@Authorized(PrivilegeConstants.ADD_COHORTS)
+	CohortMemberAttributeType createCohortMemberAttributeType(@NotNull CohortMemberAttributeType cohortMemberAttributeType);
+	
+	@Authorized(PrivilegeConstants.DELETE_COHORTS)
+	CohortMemberAttributeType deleteCohortMemberAttributeType(@NotNull CohortMemberAttributeType cohortMemberAttributeType,
+	        String voidReason);
+	
+	@Authorized(PrivilegeConstants.PURGE_COHORTS)
+	void purgeCohortMemberAttribute(CohortMemberAttributeType cohortMemberAttributeType);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteria.java
@@ -1,4 +1,5 @@
 package org.openmrs.module.cohort.api.db;
+
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -8,7 +9,6 @@ package org.openmrs.module.cohort.api.db;
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-
 import java.util.Collection;
 import java.util.Date;
 
@@ -21,8 +21,8 @@ import org.openmrs.VisitType;
 import org.openmrs.module.cohort.CohortM;
 
 /**
- * The search parameter object for encounters. A convenience interface for building
- * instances is provided by {@link EncounterSearchCriteriaBuilder}.
+ * The search parameter object for encounters. A convenience interface for building instances is
+ * provided by {@link EncounterSearchCriteriaBuilder}.
  *
  * @see EncounterSearchCriteriaBuilder
  * @since 1.12
@@ -52,23 +52,23 @@ public class EncounterSearchCriteria {
 	private boolean includeVoided;
 	
 	/**
-	 * Instead of calling this constructor directly, it is recommended to use {@link EncounterSearchCriteriaBuilder}.
+	 * Instead of calling this constructor directly, it is recommended to use
+	 * {@link EncounterSearchCriteriaBuilder}.
 	 *
-	 * @param location        the location this encounter took place
-	 * @param fromDate        the minimum date (inclusive) the encounter took place
-	 * @param toDate          the maximum date (exclusive) the encounter took place
-	 * @param dateChanged     the minimum date the encounter was changed
+	 * @param location the location this encounter took place
+	 * @param fromDate the minimum date (inclusive) the encounter took place
+	 * @param toDate the maximum date (exclusive) the encounter took place
+	 * @param dateChanged the minimum date the encounter was changed
 	 * @param enteredViaForms the form that entered this encounter must be in this collection
-	 * @param encounterTypes  the type of the encounter must be in this collection
-	 * @param providers       the provider of the encounter must be in this collection
-	 * @param visitTypes      the visit types of the encounter must be in this collection
-	 * @param visits          the visits of the encounter must be in this collection
-	 * @param includeVoided   whether to include the voided encounters or not
+	 * @param encounterTypes the type of the encounter must be in this collection
+	 * @param providers the provider of the encounter must be in this collection
+	 * @param visitTypes the visit types of the encounter must be in this collection
+	 * @param visits the visits of the encounter must be in this collection
+	 * @param includeVoided whether to include the voided encounters or not
 	 */
 	public EncounterSearchCriteria(CohortM cohort, Location location, Date fromDate, Date toDate, Date dateChanged,
-			Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes,
-			Collection<Provider> providers, Collection<VisitType> visitTypes,
-			Collection<Visit> visits, boolean includeVoided) {
+	    Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
+	    Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided) {
 		this.setCohort(cohort);
 		this.location = location;
 		this.fromDate = fromDate;
@@ -85,7 +85,6 @@ public class EncounterSearchCriteria {
 	/**
 	 * @return the patient the encounter is for
 	 */
-	
 	
 	/**
 	 * @return the location this encounter took place

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteria.java
@@ -1,6 +1,4 @@
-package org.openmrs.module.cohort.api.db;
-
-/**
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
@@ -9,6 +7,8 @@ package org.openmrs.module.cohort.api.db;
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
+package org.openmrs.module.cohort.api.db;
+
 import java.util.Collection;
 import java.util.Date;
 

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteriaBuilder.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteriaBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteriaBuilder.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/EncounterSearchCriteriaBuilder.java
@@ -21,13 +21,14 @@ import org.openmrs.VisitType;
 import org.openmrs.module.cohort.CohortM;
 
 /**
- * A convenience builder for {@link EncounterSearchCriteria}. Create a builder, set
- * its properties to desired values and finally call {@link #createEncounterSearchCriteria()}
- * to create the actual search criteria instance.
+ * A convenience builder for {@link EncounterSearchCriteria}. Create a builder, set its properties
+ * to desired values and finally call {@link #createEncounterSearchCriteria()} to create the actual
+ * search criteria instance.
  *
  * @see EncounterSearchCriteria
  */
 public class EncounterSearchCriteriaBuilder {
+	
 	private CohortM cohort;
 	
 	private Location location;
@@ -54,7 +55,6 @@ public class EncounterSearchCriteriaBuilder {
 	 * @param patient the patient the encounter is for
 	 * @return this builder instance
 	 */
-	
 	
 	/**
 	 * @param location the location the encounter took place
@@ -93,8 +93,8 @@ public class EncounterSearchCriteriaBuilder {
 	}
 	
 	/**
-	 * @param enteredViaForms the form that entered the encounter must be in this collection.
-	 *                        This search parameter is omitted if the set is null or empty.
+	 * @param enteredViaForms the form that entered the encounter must be in this collection. This
+	 *            search parameter is omitted if the set is null or empty.
 	 * @return this builder instance
 	 */
 	public EncounterSearchCriteriaBuilder setEnteredViaForms(Collection<Form> enteredViaForms) {
@@ -103,8 +103,8 @@ public class EncounterSearchCriteriaBuilder {
 	}
 	
 	/**
-	 * @param encounterTypes the type of the encounter must be in this collection.
-	 *                       This search parameter is omitted if the set is null or empty.
+	 * @param encounterTypes the type of the encounter must be in this collection. This search parameter
+	 *            is omitted if the set is null or empty.
 	 * @return this builder instance
 	 */
 	public EncounterSearchCriteriaBuilder setEncounterTypes(Collection<EncounterType> encounterTypes) {
@@ -113,8 +113,8 @@ public class EncounterSearchCriteriaBuilder {
 	}
 	
 	/**
-	 * @param providers the provider of the encounter must be in this collection.
-	 *                  This search parameter is omitted if the set is null or empty.
+	 * @param providers the provider of the encounter must be in this collection. This search parameter
+	 *            is omitted if the set is null or empty.
 	 * @return this builder instance
 	 */
 	public EncounterSearchCriteriaBuilder setProviders(Collection<Provider> providers) {
@@ -123,8 +123,8 @@ public class EncounterSearchCriteriaBuilder {
 	}
 	
 	/**
-	 * @param visitTypes the visit types of the encounter must be in this collection.
-	 *                   This search parameter is omitted if the set is null or empty.
+	 * @param visitTypes the visit types of the encounter must be in this collection. This search
+	 *            parameter is omitted if the set is null or empty.
 	 * @return this builder instance
 	 */
 	public EncounterSearchCriteriaBuilder setVisitTypes(Collection<VisitType> visitTypes) {
@@ -133,8 +133,8 @@ public class EncounterSearchCriteriaBuilder {
 	}
 	
 	/**
-	 * @param visits the visits of the encounter must be in this collection.
-	 *               This search parameter is omitted if the set is null or empty.
+	 * @param visits the visits of the encounter must be in this collection. This search parameter is
+	 *            omitted if the set is null or empty.
 	 * @return this builder instance
 	 */
 	public EncounterSearchCriteriaBuilder setVisits(Collection<Visit> visits) {
@@ -157,8 +157,8 @@ public class EncounterSearchCriteriaBuilder {
 	 * @return a new search criteria instance
 	 */
 	public EncounterSearchCriteria createEncounterSearchCriteria() {
-		return new EncounterSearchCriteria(cohort, location, fromDate, toDate, dateChanged, enteredViaForms,
-				encounterTypes, providers, visitTypes, visits, includeVoided);
+		return new EncounterSearchCriteria(cohort, location, fromDate, toDate, dateChanged, enteredViaForms, encounterTypes,
+		        providers, visitTypes, visits, includeVoided);
 	}
 	
 	public CohortM getCohort() {

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/hibernate/HibernateCohortDAO.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/hibernate/HibernateCohortDAO.java
@@ -1,15 +1,11 @@
 /*
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.cohort.api.db.hibernate;
 

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/hibernate/HibernateCohortDAO.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/hibernate/HibernateCohortDAO.java
@@ -13,6 +13,12 @@
  */
 package org.openmrs.module.cohort.api.db.hibernate;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -42,280 +48,268 @@ import org.openmrs.module.cohort.CohortVisit;
 import org.openmrs.module.cohort.api.db.CohortDAO;
 import org.openmrs.module.cohort.api.db.EncounterSearchCriteria;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 /**
- * It is a default implementation of  {@link CohortDAO}.
+ * It is a default implementation of {@link CohortDAO}.
  */
 @SuppressWarnings("unchecked")
 public class HibernateCohortDAO implements CohortDAO {
-
+	
 	protected final Log log = LogFactory.getLog(this.getClass());
-
+	
 	private SessionFactory sessionFactory;
-
+	
 	/**
 	 * @return the sessionFactory
 	 */
 	public SessionFactory getSessionFactory() {
 		return sessionFactory;
 	}
-
+	
 	/**
 	 * @param sessionFactory the sessionFactory to set
 	 */
 	public void setSessionFactory(SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
-
+	
 	@Override
 	public CohortAttribute saveCohortAttributes(CohortAttribute att) {
 		getCurrentSession().saveOrUpdate(att);
 		return att;
 	}
-
+	
 	@Override
 	public List<CohortAttribute> findCohortAttribute(String name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortAttribute.class);
 		criteria.add(Restrictions.ilike("value", name, MatchMode.START));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public CohortMember saveCPatient(CohortMember cohortMember) {
 		getCurrentSession().saveOrUpdate(cohortMember);
 		return cohortMember;
 	}
-
+	
 	@Override
 	public CohortType saveCohortType(CohortType cohorttype) {
 		getCurrentSession().saveOrUpdate(cohorttype);
 		return cohorttype;
 	}
-
+	
 	@Override
 	public List<CohortType> findCohortType() {
 		Query queryResult = getCurrentSession().createQuery("from CohortType");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public List<CohortType> getAllCohortTypes() {
 		Query queryResult = getCurrentSession().createQuery("from CohortType");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public List<CohortType> findCohortType(String cohort_name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortType.class);
 		criteria.add(Restrictions.ilike("name", cohort_name, MatchMode.START));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public void purgeCohortType(CohortType cohort) {
 		getCurrentSession().delete(cohort);
 	}
-
+	
 	@Override
 	public void purgeCohortAtt(CohortAttribute att) {
 		getCurrentSession().delete(att);
 	}
-
+	
 	@Override
 	public List<CohortAttributeType> getAllCohortAttributes() {
 		Query queryResult = getCurrentSession().createQuery("from CohortAttributeType");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortAttributeType findCohortAttributes(String attribute_type_name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortAttributeType.class);
 		criteria.add(Restrictions.eq("name", attribute_type_name));
 		return (CohortAttributeType) criteria.uniqueResult();
 	}
-
+	
 	@Override
 	public void purgeCohortAttributes(CohortAttributeType attributes) {
 		getCurrentSession().delete(attributes);
 	}
-
+	
 	@Override
 	public void purgeCohortEncounters(CohortEncounter cencounters) {
 		getCurrentSession().delete(cencounters);
 	}
-
+	
 	@Override
 	public CohortType getCohortType(Integer id) {
 		return (CohortType) getCurrentSession().get(CohortType.class, id);
 	}
-
+	
 	@Override
-	public CohortAttributeType saveCohortAttributes(
-			CohortAttributeType attributes) {
+	public CohortAttributeType saveCohortAttributes(CohortAttributeType attributes) {
 		getCurrentSession().saveOrUpdate(attributes);
 		return attributes;
 	}
-
+	
 	@Override
-	public CohortAttributeType getCohortAttributes(
-			Integer cohort_attribute_type_id) {
+	public CohortAttributeType getCohortAttributes(Integer cohort_attribute_type_id) {
 		return (CohortAttributeType) getCurrentSession().get(CohortAttributeType.class, cohort_attribute_type_id);
 	}
-
+	
 	@Override
 	public CohortEncounter saveCohortEncounters(CohortEncounter cencounters) {
 		getCurrentSession().saveOrUpdate(cencounters);
 		return cencounters;
 	}
-
+	
 	@Override
 	public List<CohortEncounter> findCohortEncounters() {
 		Query queryResult = getCurrentSession().createQuery("from CohortEncounter");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortM saveCohort(CohortM cohort) {
 		getCurrentSession().saveOrUpdate(cohort);
 		return cohort;
 	}
-
+	
 	@Override
 	public void purgeCohort(CohortM cohort) {
 		getCurrentSession().delete(cohort);
 	}
-
+	
 	@Override
 	public CohortM getCohort(Integer id) {
 		return (CohortM) getCurrentSession().get(CohortM.class, id);
 	}
-
+	
 	@Override
 	public List<CohortM> findCohorts() {
 		return (List<CohortM>) getCurrentSession().createQuery("from CohortM").list();
 	}
-
+	
 	@Override
 	public List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortM.class);
-
+		
 		if (StringUtils.isNotBlank(nameMatching)) {
 			criteria.add(Restrictions.ilike("name", nameMatching, MatchMode.ANYWHERE));
 		}
-
+		
 		if (attributes != null && !attributes.isEmpty()) {
-			Criteria cri = criteria.createCriteria("attributes")
-					.add(Restrictions.eq("voided", false))
-					.createAlias("cohortAttributeType", "attrType");
-
+			Criteria cri = criteria.createCriteria("attributes").add(Restrictions.eq("voided", false))
+			        .createAlias("cohortAttributeType", "attrType");
+			
 			Disjunction dis = Restrictions.disjunction();
 			for (String k : attributes.keySet()) {
-				dis.add(Restrictions.conjunction(
-						Restrictions.eq("attrType.name", k), Restrictions.like("value", attributes.get(k), MatchMode.ANYWHERE)));
+				dis.add(Restrictions.conjunction(Restrictions.eq("attrType.name", k),
+				    Restrictions.like("value", attributes.get(k), MatchMode.ANYWHERE)));
 			}
-
+			
 			cri.add(dis);
 		}
-
+		
 		if (cohortType != null) {
 			criteria.add(Restrictions.eq("cohortType.cohortTypeId", cohortType.getCohortTypeId()));
 		}
-
+		
 		criteria.setProjection(null).setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
-
+		
 		return criteria.list();
 	}
-
+	
 	@Override
 	public CohortVisit saveCohortVisit(CohortVisit cvisit) {
 		getCurrentSession().saveOrUpdate(cvisit);
 		return cvisit;
 	}
-
+	
 	@Override
 	public void purgeCohortVisit(CohortVisit cvisit) {
 		getCurrentSession().delete(cvisit);
 	}
-
+	
 	@Override
 	public CohortLeader getCohortLeaderByUuid(String uuid) {
 		return (CohortLeader) getCurrentSession().createQuery("from CohortLeader t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortLeader getCohortLeaderById(Integer id) {
 		return (CohortLeader) getCurrentSession().get(CohortLeader.class, id);
 	}
-
+	
 	@Override
 	public List<CohortLeader> getCohortLeadersByCohortId(Integer id) {
 		return getCurrentSession().createCriteria(CohortLeader.class, "cohortLeader")
-				.createAlias("cohortLeader.cohort", "cohort")
-				.add(Restrictions.eq("cohort.cohortId", id))
-				.add(Restrictions.eq("cohortLeader.voided", false))
-				.list();
+		        .createAlias("cohortLeader.cohort", "cohort").add(Restrictions.eq("cohort.cohortId", id))
+		        .add(Restrictions.eq("cohortLeader.voided", false)).list();
 	}
-
+	
 	@Override
 	public CohortLeader saveCohortLeader(CohortLeader cohortLeader) {
 		getCurrentSession().saveOrUpdate(cohortLeader);
 		return cohortLeader;
 	}
-
+	
 	@Override
 	public void purgeCohortLeader(CohortLeader cohortLeader) {
 		getCurrentSession().delete(cohortLeader);
 	}
-
+	
 	@Override
 	public CohortMemberVisit getCohortMemberVisitByUuid(String uuid) {
 		return (CohortMemberVisit) getCurrentSession().createQuery("from CohortMemberVisit t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortMemberVisit saveCohortMemberVisit(CohortMemberVisit cohortMemberVisit) {
 		getCurrentSession().saveOrUpdate(cohortMemberVisit);
 		return cohortMemberVisit;
 	}
-
+	
 	@Override
 	public List<CohortMember> getCohortMembersByPatientId(int patientId) {
 		return (List<CohortMember>) getCurrentSession().createQuery("from CohortMember t where t.patient.patientId = :id")
-				.setInteger("id", patientId).list();
+		        .setInteger("id", patientId).list();
 	}
-
+	
 	@Override
 	public List<CohortAttribute> getCohortAttributesByAttributeType(Integer attributeTypeId) {
 		return (List<CohortAttribute>) getCurrentSession()
-				.createQuery("from CohortAttribute t where t.cohortAttributeType.cohortAttributeTypeId = :attributeTypeId")
-				.setInteger("attributeTypeId", attributeTypeId).list();
+		        .createQuery("from CohortAttribute t where t.cohortAttributeType.cohortAttributeTypeId = :attributeTypeId")
+		        .setInteger("attributeTypeId", attributeTypeId).list();
 	}
-
+	
 	@Override
 	public List<CohortVisit> findCohortVisitByVisitType(Integer visitType) {
 		Query queryResult = getCurrentSession().createQuery("from CohortVisit");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortM getCohortByName(String name) {
 		return (CohortM) getCurrentSession().createQuery("from CohortM t where t.name = :name").setString("name", name)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortM getCohortUuid(String uuid) {
-		return (CohortM) getCurrentSession().createCriteria(CohortM.class)
-				.add(Restrictions.eq("uuid", uuid)).uniqueResult();
+		return (CohortM) getCurrentSession().createCriteria(CohortM.class).add(Restrictions.eq("uuid", uuid)).uniqueResult();
 	}
-
+	
 	@Override
 	public List<CohortEncounter> findCohortEncounters(String name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortEncounter.class);
@@ -323,7 +317,7 @@ public class HibernateCohortDAO implements CohortDAO {
 		criteria.add(Restrictions.eq("voided", false));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public List<CohortVisit> findCohortVisit(String name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortVisit.class);
@@ -331,166 +325,166 @@ public class HibernateCohortDAO implements CohortDAO {
 		criteria.add(Restrictions.eq("voided", false));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public CohortEncounter getCohortEncounterUuid(String uuid) {
 		return (CohortEncounter) getCurrentSession().createQuery("from CohortEncounter t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortMember getCohortMemUuid(String uuid) {
 		return (CohortMember) getCurrentSession().createQuery("from CohortMember t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortType getCohortTypeByName(String name) {
 		return (CohortType) getCurrentSession().createQuery("from CohortType t where t.name = :name").setString("name", name)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortAttributeType getCohortAttributeTypeUuid(String uuid) {
 		return (CohortAttributeType) getCurrentSession().createQuery("from CohortAttributeType t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public List<CohortMember> findCohortMember() {
 		Session session = getCurrentSession();
 		Query queryResult = session.createQuery("from CohortMember");
 		return queryResult.list();
-
+		
 	}
-
+	
 	@Override
 	public CohortVisit findCohortVisit(Integer id) {
 		return (CohortVisit) getCurrentSession().get(CohortVisit.class, id);
 	}
-
+	
 	@Override
 	public CohortType findCohortType(Integer id) {
 		return (CohortType) getCurrentSession().get(CohortType.class, id);
 	}
-
+	
 	@Override
 	public CohortAttribute getCohortAttribute(Integer id) {
 		return (CohortAttribute) getCurrentSession().get(CohortAttribute.class, id);
 	}
-
+	
 	@Override
 	public CohortAttributeType findCohortAttributeType(Integer id) {
 		return (CohortAttributeType) getCurrentSession().get(CohortAttributeType.class, id);
 	}
-
+	
 	@Override
 	public CohortEncounter findCohortEncounter(Integer id) {
 		return (CohortEncounter) getCurrentSession().get(CohortEncounter.class, id);
 	}
-
+	
 	@Override
 	public CohortProgram saveCohortProgram(CohortProgram cohort) {
 		getCurrentSession().saveOrUpdate(cohort);
 		return cohort;
 	}
-
+	
 	@Override
 	public void purgeCohortProgram(CohortProgram cvisit) {
 		getCurrentSession().delete(cvisit);
 	}
-
+	
 	@Override
 	public List<CohortProgram> findCohortProg() {
 		Session session = getCurrentSession();
 		Query queryResult = session.createQuery("from CohortProgram");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortProgram findCohortProgram(String name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortProgram.class);
 		criteria.add(Restrictions.eq("name", name));
 		return (CohortProgram) criteria.uniqueResult();
 	}
-
+	
 	@Override
 	public CohortProgram getCohortProgramUuid(String uuid) {
 		return (CohortProgram) getCurrentSession().createQuery("from CohortProgram t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortProgram findCohortProgram(Integer id) {
 		return (CohortProgram) getCurrentSession().get(CohortProgram.class, id);
 	}
-
+	
 	@Override
 	public CohortObs saveCohortObs(CohortObs cobs) {
 		getCurrentSession().saveOrUpdate(cobs);
 		return cobs;
 	}
-
+	
 	@Override
 	public void purgeCohortObs(CohortObs cobs) {
 		getCurrentSession().delete(cobs);
 	}
-
+	
 	@Override
 	public List<CohortObs> findCohortObs() {
 		Session session = getCurrentSession();
 		Query queryResult = session.createQuery("from CohortObs");
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortObs findCohortObs(Integer id) {
 		return (CohortObs) getCurrentSession().get(CohortObs.class, id);
 	}
-
+	
 	@Override
 	public CohortObs getCohortObsUuid(String uuid) {
 		return (CohortObs) getCurrentSession().createQuery("from CohortObs t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortRole saveCohortRole(CohortRole cohort) {
 		getCurrentSession().saveOrUpdate(cohort);
 		return cohort;
 	}
-
+	
 	@Override
 	public List<CohortRole> findRoles(String name) {
 		Session session = getCurrentSession();
-		Query queryResult = session.createQuery(
-				"from CohortRole r where r.cohortType=(select m.cohortType from CohortM m where m.name=:name)")
-				.setParameter("name", name);
+		Query queryResult = session
+		        .createQuery("from CohortRole r where r.cohortType=(select m.cohortType from CohortM m where m.name=:name)")
+		        .setParameter("name", name);
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public List<CohortRole> findCohortRoles(String name) {
 		Session session = getCurrentSession();
 		Query queryResult = session.createQuery("from CohortRole where name=:name").setParameter("name", name);
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public CohortRole getCohortRoleUuid(String uuid) {
 		return (CohortRole) getCurrentSession().createQuery("from CohortRole t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortEncounter getCohortEncounter(Integer id) {
 		return (CohortEncounter) getCurrentSession().get(CohortEncounter.class, id);
 	}
-
+	
 	@Override
 	public List<CohortEncounter> getEncounters(EncounterSearchCriteria searchCriteria) {
 		Criteria crit = getCurrentSession().createCriteria(CohortEncounter.class);
-
+		
 		if (searchCriteria.getCohort() != null && searchCriteria.getCohort().getCohortId() != null) {
 			crit.add(Restrictions.eq("cohort", searchCriteria.getCohort()));
 		}
@@ -515,34 +509,34 @@ public class HibernateCohortDAO implements CohortDAO {
 		crit.addOrder(Order.asc("encounterDatetime"));
 		return crit.list();
 	}
-
+	
 	@Override
 	@SuppressWarnings("unchecked")
-	public List<CohortEncounter> getEncounters(String query, Integer cohortId,
-			Integer start, Integer length, boolean includeVoided) {
+	public List<CohortEncounter> getEncounters(String query, Integer cohortId, Integer start, Integer length,
+	        boolean includeVoided) {
 		if (StringUtils.isBlank(query) && cohortId == null) {
 			return Collections.emptyList();
 		}
-
+		
 		Criteria criteria = createEncounterByQueryCriteria(query, cohortId, includeVoided, true);
-
+		
 		if (start != null) {
 			criteria.setFirstResult(start);
 		}
 		if (length != null && length > 0) {
 			criteria.setMaxResults(length);
 		}
-
+		
 		return criteria.list();
 	}
-
+	
 	private Criteria createEncounterByQueryCriteria(String query, Integer cohortId, boolean includeVoided,
-			boolean orderByNames) {
+	        boolean orderByNames) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortEncounter.class, "enc");
 		if (!includeVoided) {
 			criteria.add(Restrictions.eq("enc.voided", false));
 		}
-
+		
 		criteria = criteria.createCriteria("cohort", "coh");
 		if (cohortId != null) {
 			criteria.add(Restrictions.eq("coh.cohortId", cohortId));
@@ -558,14 +552,14 @@ public class HibernateCohortDAO implements CohortDAO {
 				criteria.createAlias("enc_prov.provider", "prov");
 				criteria.createAlias("prov.person", "person", JoinType.LEFT_OUTER_JOIN);
 				criteria.createAlias("person.names", "personName", JoinType.LEFT_OUTER_JOIN);
-
+				
 				Disjunction or = Restrictions.disjunction();
 				or.add(Restrictions.ilike("loc.name", query, mode));
 				or.add(Restrictions.ilike("encType.name", query, mode));
 				or.add(Restrictions.ilike("form.name", query, mode));
 				or.add(Restrictions.ilike("prov.name", query, mode));
 				or.add(Restrictions.ilike("prov.identifier", query, mode));
-
+				
 				String[] splitNames = query.split(" ");
 				Disjunction nameOr = Restrictions.disjunction();
 				for (String splitName : splitNames) {
@@ -586,9 +580,9 @@ public class HibernateCohortDAO implements CohortDAO {
 				Conjunction personNameConjuction = Restrictions.conjunction();
 				personNameConjuction.add(Restrictions.eq("personName.voided", false));
 				personNameConjuction.add(nameOr);
-
+				
 				or.add(personNameConjuction);
-
+				
 				criteria.add(or);
 			}
 		} else {
@@ -601,12 +595,12 @@ public class HibernateCohortDAO implements CohortDAO {
 				name = query;
 			}
 			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(name, identifier,
-					new ArrayList<>(), false, orderByNames, false);
+			    new ArrayList<>(), false, orderByNames, false);
 		}
-
+		
 		return criteria;
 	}
-
+	
 	@Override
 	public List<CohortRole> findCohortRole(String cohort_name) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortRole.class);
@@ -614,25 +608,24 @@ public class HibernateCohortDAO implements CohortDAO {
 		criteria.add(Restrictions.eq("voided", false));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public CohortRole findCohortRole(Integer id) {
 		return (CohortRole) getCurrentSession().get(CohortRole.class, id);
 	}
-
+	
 	@Override
 	public void purgeCohortRole(CohortRole crole) {
 		getCurrentSession().delete(crole);
 	}
-
+	
 	@Override
 	public Long getCount(String name) {
 		return (Long) getCurrentSession()
-				.createQuery("select count(*) from CohortMember c left outer join c.cohort m where m.name=:name")
-				.setParameter("name", name)
-				.uniqueResult();
+		        .createQuery("select count(*) from CohortMember c left outer join c.cohort m where m.name=:name")
+		        .setParameter("name", name).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortObs saveObs(CohortObs obs) {
 		if (obs.hasGroupMembers() && obs.getCohortObsId() != null) {
@@ -645,27 +638,27 @@ public class HibernateCohortDAO implements CohortDAO {
 				}
 			}
 		}
-
+		
 		getCurrentSession().saveOrUpdate(obs);
-
+		
 		return obs;
 	}
-
+	
 	@Override
 	public CohortMember getCohortMember(Integer id) {
 		return (CohortMember) getCurrentSession().get(CohortMember.class, id);
 	}
-
+	
 	@Override
 	// FIXME Does this work?
 	public List<CohortMember> findCohortMember(String name) {
 		Session session = getCurrentSession();
 		Query queryResult = session
-				.createQuery("from CohortMember where patient=(select patientId from Person where names=:name")
-				.setParameter("name", name);
+		        .createQuery("from CohortMember where patient=(select patientId from Person where names=:name")
+		        .setParameter("name", name);
 		return queryResult.list();
 	}
-
+	
 	@Override
 	public List<CohortEncounter> findCohortEncounter(String cohort, String location) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortEncounter.class);
@@ -673,13 +666,13 @@ public class HibernateCohortDAO implements CohortDAO {
 		criteria.add(Restrictions.ilike("location", location, MatchMode.START));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public List<CohortMember> findCohortMembersByCohortId(Integer cohortId) {
 		return getCurrentSession().createQuery("from CohortMember where cohort = :cohortId")
-				.setParameter("cohortId", cohortId).list();
+		        .setParameter("cohortId", cohortId).list();
 	}
-
+	
 	/**
 	 * Gets the current hibernate session while taking care of the hibernate 3 and 4 differences.
 	 *
@@ -688,141 +681,141 @@ public class HibernateCohortDAO implements CohortDAO {
 	private org.hibernate.Session getCurrentSession() {
 		return sessionFactory.getCurrentSession();
 	}
-
+	
 	@Override
 	public CohortAttribute getCohortAttributeById(Integer id) {
 		return (CohortAttribute) getCurrentSession().get(CohortAttribute.class, id);
 	}
-
+	
 	@Override
 	public CohortAttribute getCohortAttributeByUuid(String uuid) {
 		return (CohortAttribute) getCurrentSession().createQuery("from CohortAttribute t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortAttributeType getCohortAttributeTypeById(Integer id) {
 		return (CohortAttributeType) getCurrentSession().get(CohortAttributeType.class, id);
 	}
-
+	
 	@Override
 	public CohortAttributeType getCohortAttributeTypeByUuid(String uuid) {
 		return (CohortAttributeType) getCurrentSession().createQuery("from CohortAttributeType t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortEncounter getCohortEncounterById(Integer id) {
 		return (CohortEncounter) getCurrentSession().get(CohortEncounter.class, id);
 	}
-
+	
 	@Override
 	public CohortEncounter getCohortEncounterByUuid(String uuid) {
 		return (CohortEncounter) getCurrentSession().createQuery("from CohortEncounter t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortM getCohortMById(Integer id) {
 		return (CohortM) getCurrentSession().get(CohortM.class, id);
 	}
-
+	
 	@Override
 	public CohortM getCohortMByUuid(String uuid) {
 		return (CohortM) getCurrentSession().createQuery("from CohortM t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortMember getCohortMemberById(Integer id) {
 		return (CohortMember) getCurrentSession().get(CohortMember.class, id);
 	}
-
+	
 	@Override
 	public CohortMember getCohortMemberByUuid(String uuid) {
 		return (CohortMember) getCurrentSession().createQuery("from CohortMember t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortObs getCohortObsById(Integer id) {
 		return (CohortObs) getCurrentSession().get(CohortObs.class, id);
 	}
-
+	
 	@Override
 	public CohortObs getCohortObsByUuid(String uuid) {
 		return (CohortObs) getCurrentSession().createQuery("from CohortObs t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortProgram getCohortProgramById(Integer id) {
 		return (CohortProgram) getCurrentSession().get(CohortProgram.class, id);
 	}
-
+	
 	@Override
 	public CohortProgram getCohortProgramByUuid(String uuid) {
 		return (CohortProgram) getCurrentSession().createQuery("from CohortProgram t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public CohortRole getCohortRoleById(Integer id) {
 		return (CohortRole) getCurrentSession().get(CohortRole.class, id);
 	}
-
+	
 	@Override
 	public CohortRole getCohortRoleByUuid(String uuid) {
 		return (CohortRole) getCurrentSession().createQuery("from CohortRole t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortType getCohortTypeById(Integer id) {
 		return (CohortType) getCurrentSession().get(CohortType.class, id);
 	}
-
+	
 	@Override
 	public CohortType getCohortTypeByUuid(String uuid) {
 		return (CohortType) getCurrentSession().createQuery("from CohortType t where t.uuid = :uuid").setString("uuid", uuid)
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public CohortVisit getCohortVisitById(Integer id) {
 		return (CohortVisit) getCurrentSession().get(CohortVisit.class, id);
 	}
-
+	
 	@Override
 	public CohortVisit getCohortVisitByUuid(String uuid) {
 		return (CohortVisit) getCurrentSession().createQuery("from CohortVisit t where t.uuid = :uuid")
-				.setString("uuid", uuid).uniqueResult();
+		        .setString("uuid", uuid).uniqueResult();
 	}
-
+	
 	@Override
 	public List<CohortM> getCohortsByLocationId(Integer id) {
 		return (List<CohortM>) getCurrentSession().createQuery("from CohortM t where t.location.locationId = :id")
-				.setString("id", id.toString()).list();
+		        .setString("id", id.toString()).list();
 	}
-
+	
 	@Override
 	public List<CohortM> getCohortByCohortTypeId(Integer id) {
 		return (List<CohortM>) getCurrentSession().createQuery("from CohortM t where t.cohortType.cohortTypeId = :id")
-				.setString("id", id.toString()).list();
+		        .setString("id", id.toString()).list();
 	}
-
+	
 	@Override
 	public List<CohortM> getCohortByCohortProgramId(Integer id) {
 		return (List<CohortM>) getCurrentSession().createQuery("from CohortM t where t.cohortProgram.cohortProgramId = :id")
-				.setString("id", id.toString()).list();
+		        .setString("id", id.toString()).list();
 	}
-
+	
 	@Override
 	public List<CohortMember> getCohortMembersByCohortRoleId(Integer id) {
 		return (List<CohortMember>) getCurrentSession().createQuery("from CohortM t where t.role.cohortProgramId = :id")
-				.setString("id", id.toString()).list();
+		        .setString("id", id.toString()).list();
 	}
-
+	
 	@Override
 	public CohortM getCohort(Integer locationId, Integer programId, Integer typeId) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortM.class, "cohort");
@@ -840,33 +833,33 @@ public class HibernateCohortDAO implements CohortDAO {
 		}
 		return (CohortM) criteria.uniqueResult();
 	}
-
+	
 	@Override
 	public List<CohortMember> getCohortMembersByCohortId(Integer id) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortMember.class, "cohortMember")
-				.createAlias("cohortMember.cohort", "cohort");
+		        .createAlias("cohortMember.cohort", "cohort");
 		criteria.add(Restrictions.eq("cohort.cohortId", id));
 		return criteria.list();
 	}
-
+	
 	@Override
 	public List<CohortRole> getAllCohortRoles() {
 		return getCurrentSession().createCriteria(CohortRole.class).list();
 	}
-
+	
 	@Override
 	public CohortRole getCohortRoleByName(String name) {
 		return (CohortRole) getCurrentSession().createCriteria(CohortRole.class).add(Restrictions.eq("name", name))
-				.uniqueResult();
+		        .uniqueResult();
 	}
-
+	
 	@Override
 	public void deleteCohortRoleById(Integer id) {
 		CohortRole cr = (CohortRole) getCurrentSession().createCriteria(CohortRole.class)
-				.add(Restrictions.eq("cohortRoleId", id)).uniqueResult();
+		        .add(Restrictions.eq("cohortRoleId", id)).uniqueResult();
 		getCurrentSession().delete(cr);
 	}
-
+	
 	@Override
 	public List<CohortAttribute> findCohortAttributes(Integer cohortId, Integer attributeTypeId) {
 		Criteria cri = getCurrentSession().createCriteria(CohortAttribute.class);
@@ -874,34 +867,34 @@ public class HibernateCohortDAO implements CohortDAO {
 			cri.createAlias("cohort", "c");
 			cri.add(Restrictions.eq("c.cohortId", cohortId));
 		}
-
+		
 		if (attributeTypeId != null) {
 			cri.createAlias("cohortAttributeType", "a");
 			cri.add(Restrictions.eq("a.cohortAttributeTypeId", attributeTypeId));
 		}
 		return cri.list();
 	}
-
+	
 	@Override
 	public List<CohortVisit> getCohortVisitsByLocationId(Integer id) {
 		return (List<CohortVisit>) getCurrentSession().createCriteria(CohortVisit.class, "cv")
-				.createAlias("cv.location", "location").add(Restrictions.eq("location.locationId", id)).list();
+		        .createAlias("cv.location", "location").add(Restrictions.eq("location.locationId", id)).list();
 	}
-
+	
 	@Override
 	public List<CohortMember> getAllHeadCohortMembers() {
 		return getCurrentSession().createCriteria(CohortMember.class).add(Restrictions.eq("head", true)).list();
 	}
-
+	
 	@Override
 	public List<CohortObs> getCohortObsByEncounterId(Integer id) {
 		return getCurrentSession().createCriteria(CohortObs.class, "cohortObs")
-				.createAlias("cohortObs.encounter", "encounter").add(Restrictions.eq("encounter.encounterId", id)).list();
+		        .createAlias("cohortObs.encounter", "encounter").add(Restrictions.eq("encounter.encounterId", id)).list();
 	}
-
+	
 	@Override
 	public List<CohortVisit> getCohortVisitsByDate(Date startDate, Date endDate) {
 		return getCurrentSession().createCriteria(CohortVisit.class).add(Restrictions.ge("startDate", startDate))
-				.add(Restrictions.le("endDate", endDate)).list();
+		        .add(Restrictions.le("endDate", endDate)).list();
 	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeDaoImpl.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.cohort.api.db.impl;
 
+import java.util.Date;
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Setter;
 import org.hibernate.SessionFactory;
@@ -20,54 +23,50 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.List;
-
 @Component
 public class CohortMemberAttributeDaoImpl implements CohortMemberAttributeDao {
-
-    @Autowired
-    @Setter(AccessLevel.PACKAGE)
-    @Qualifier("sessionFactory")
-    private SessionFactory sessionFactory;
-
-    protected org.hibernate.Session getCurrentSession() {
-        return sessionFactory.getCurrentSession();
-    }
-
-    @Override
-    public CohortMemberAttribute getCohortMemberAttributeByUuid(String uuid) {
-        return (CohortMemberAttribute) getCurrentSession().createCriteria(CohortMemberAttribute.class).add(
-                Restrictions.eq("uuid", uuid)).uniqueResult();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public List<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(String attributeTypeUuid) {
-        return getCurrentSession().createCriteria(CohortMemberAttribute.class)
-                .createAlias("attributeType", "cm").add(
-                Restrictions.eq("cm.uuid", attributeTypeUuid)).list();
-    }
-
-    @Override
-    public CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
-        getCurrentSession().saveOrUpdate(cohortMemberAttribute);
-        return cohortMemberAttribute;
-    }
-
-    @Override
-    public CohortMemberAttribute deleteCohortMemberAttribute(String uuid) {
-        CohortMemberAttribute cohortMemberAttribute = getCohortMemberAttributeByUuid(uuid);
-        cohortMemberAttribute.setVoided(true);
-        cohortMemberAttribute.setDateVoided(new Date());
-        cohortMemberAttribute.setVoidReason("Voided via cohort rest call");
-        cohortMemberAttribute.setVoidedBy(Context.getAuthenticatedUser());
-        getCurrentSession().saveOrUpdate(cohortMemberAttribute);
-        return cohortMemberAttribute;
-    }
-
-    @Override
-    public void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
-        getCurrentSession().delete(cohortMemberAttribute);
-    }
+	
+	@Autowired
+	@Setter(AccessLevel.PACKAGE)
+	@Qualifier("sessionFactory")
+	private SessionFactory sessionFactory;
+	
+	protected org.hibernate.Session getCurrentSession() {
+		return sessionFactory.getCurrentSession();
+	}
+	
+	@Override
+	public CohortMemberAttribute getCohortMemberAttributeByUuid(String uuid) {
+		return (CohortMemberAttribute) getCurrentSession().createCriteria(CohortMemberAttribute.class)
+		        .add(Restrictions.eq("uuid", uuid)).uniqueResult();
+	}
+	
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(String attributeTypeUuid) {
+		return getCurrentSession().createCriteria(CohortMemberAttribute.class).createAlias("attributeType", "cm")
+		        .add(Restrictions.eq("cm.uuid", attributeTypeUuid)).list();
+	}
+	
+	@Override
+	public CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
+		getCurrentSession().saveOrUpdate(cohortMemberAttribute);
+		return cohortMemberAttribute;
+	}
+	
+	@Override
+	public CohortMemberAttribute deleteCohortMemberAttribute(String uuid) {
+		CohortMemberAttribute cohortMemberAttribute = getCohortMemberAttributeByUuid(uuid);
+		cohortMemberAttribute.setVoided(true);
+		cohortMemberAttribute.setDateVoided(new Date());
+		cohortMemberAttribute.setVoidReason("Voided via cohort rest call");
+		cohortMemberAttribute.setVoidedBy(Context.getAuthenticatedUser());
+		getCurrentSession().saveOrUpdate(cohortMemberAttribute);
+		return cohortMemberAttribute;
+	}
+	
+	@Override
+	public void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
+		getCurrentSession().delete(cohortMemberAttribute);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeTypeDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeTypeDaoImpl.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.cohort.api.db.impl;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,52 +26,50 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import javax.validation.constraints.NotNull;
-import java.util.List;
-
 @Slf4j
 @Component
 @Setter(AccessLevel.PACKAGE)
 @Getter(AccessLevel.PACKAGE)
 public class CohortMemberAttributeTypeDaoImpl implements CohortMemberAttributeTypeDao {
-
-    @Autowired
-    @Qualifier("sessionFactory")
-    private SessionFactory sessionFactory;
-
-    protected org.hibernate.Session getSession() {
-        return sessionFactory.getCurrentSession();
-    }
-
-    @Override
-    public CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(String uuid) {
-        return (CohortMemberAttributeType) getSession().createCriteria(CohortMemberAttributeType.class).add(
-                Restrictions.eq("uuid", uuid)).uniqueResult();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<CohortMemberAttributeType> getCohortMemberAttributeTypes() {
-        return getSession().createCriteria(CohortMemberAttributeType.class).list();
-    }
-
-    @Override
-    public CohortMemberAttributeType createCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
-        getSession().saveOrUpdate(cohortMemberAttributeType);
-        return cohortMemberAttributeType;
-    }
-
-    @Override
-    public CohortMemberAttributeType deleteCohortMemberAttributeType(@NotNull CohortMemberAttributeType cohortMemberAttributeType, String voidReason) {
-        cohortMemberAttributeType.setRetired(true);
-        cohortMemberAttributeType.setRetireReason(voidReason);
-        cohortMemberAttributeType.setRetiredBy(Context.getAuthenticatedUser());
-        getSession().saveOrUpdate(cohortMemberAttributeType);
-        return cohortMemberAttributeType;
-    }
-
-    @Override
-    public void purgeCohortMemberAttribute(CohortMemberAttributeType cohortMemberAttributeType) {
-        getSession().delete(cohortMemberAttributeType);
-    }
+	
+	@Autowired
+	@Qualifier("sessionFactory")
+	private SessionFactory sessionFactory;
+	
+	protected org.hibernate.Session getSession() {
+		return sessionFactory.getCurrentSession();
+	}
+	
+	@Override
+	public CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(String uuid) {
+		return (CohortMemberAttributeType) getSession().createCriteria(CohortMemberAttributeType.class)
+		        .add(Restrictions.eq("uuid", uuid)).uniqueResult();
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<CohortMemberAttributeType> getCohortMemberAttributeTypes() {
+		return getSession().createCriteria(CohortMemberAttributeType.class).list();
+	}
+	
+	@Override
+	public CohortMemberAttributeType createCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
+		getSession().saveOrUpdate(cohortMemberAttributeType);
+		return cohortMemberAttributeType;
+	}
+	
+	@Override
+	public CohortMemberAttributeType deleteCohortMemberAttributeType(
+	        @NotNull CohortMemberAttributeType cohortMemberAttributeType, String voidReason) {
+		cohortMemberAttributeType.setRetired(true);
+		cohortMemberAttributeType.setRetireReason(voidReason);
+		cohortMemberAttributeType.setRetiredBy(Context.getAuthenticatedUser());
+		getSession().saveOrUpdate(cohortMemberAttributeType);
+		return cohortMemberAttributeType;
+	}
+	
+	@Override
+	public void purgeCohortMemberAttribute(CohortMemberAttributeType cohortMemberAttributeType) {
+		getSession().delete(cohortMemberAttributeType);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImpl.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.cohort.api.impl;
 
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Setter;
 import org.openmrs.api.impl.BaseOpenmrsService;
@@ -21,62 +23,61 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Component("cohortMemberService")
 @Setter(AccessLevel.PACKAGE)
 @Transactional
 public class CohortMemberServiceImpl extends BaseOpenmrsService implements CohortMemberService {
-
-    @Autowired
-    private CohortMemberAttributeTypeDao attributeTypeDao;
-
-    @Autowired
-    private CohortMemberAttributeDao attributeDao;
-
-    @Override
-    public CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(String uuid) {
-        return attributeTypeDao.getCohortMemberAttributeTypeByUuid(uuid);
-    }
-
-    @Override
-    public List<CohortMemberAttributeType> getAllCohortMemberAttributeTypes() {
-        return attributeTypeDao.getCohortMemberAttributeTypes();
-    }
-
-    @Override
-    @Transactional
-    public CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
-        return attributeTypeDao.createCohortMemberAttributeType(cohortMemberAttributeType);
-    }
-
-    @Override
-    public CohortMemberAttributeType deleteCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason) {
-        return attributeTypeDao.deleteCohortMemberAttributeType(cohortMemberAttributeType, voidReason);
-    }
-
-    @Override
-    public void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
-        attributeTypeDao.purgeCohortMemberAttribute(cohortMemberAttributeType);
-    }
-
-    @Override
-    public CohortMemberAttribute getCohortMemberAttributeByUuid(String uuid) {
-        return attributeDao.getCohortMemberAttributeByUuid(uuid);
-    }
-
-    @Override
-    public List<CohortMemberAttribute> getCohortMemberAttributeByTypeUuid(String attributeTypeUuid) {
-        return attributeDao.getCohortMemberAttributesByTypeUuid(attributeTypeUuid);
-    }
-
-    @Override
-    public CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
-        return attributeDao.saveCohortMemberAttribute(cohortMemberAttribute);
-    }
-
-    @Override
-    public void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
-        attributeDao.purgeCohortMemberAttribute(cohortMemberAttribute);
-    }
+	
+	@Autowired
+	private CohortMemberAttributeTypeDao attributeTypeDao;
+	
+	@Autowired
+	private CohortMemberAttributeDao attributeDao;
+	
+	@Override
+	public CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(String uuid) {
+		return attributeTypeDao.getCohortMemberAttributeTypeByUuid(uuid);
+	}
+	
+	@Override
+	public List<CohortMemberAttributeType> getAllCohortMemberAttributeTypes() {
+		return attributeTypeDao.getCohortMemberAttributeTypes();
+	}
+	
+	@Override
+	@Transactional
+	public CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
+		return attributeTypeDao.createCohortMemberAttributeType(cohortMemberAttributeType);
+	}
+	
+	@Override
+	public CohortMemberAttributeType deleteCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType,
+	        String voidReason) {
+		return attributeTypeDao.deleteCohortMemberAttributeType(cohortMemberAttributeType, voidReason);
+	}
+	
+	@Override
+	public void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
+		attributeTypeDao.purgeCohortMemberAttribute(cohortMemberAttributeType);
+	}
+	
+	@Override
+	public CohortMemberAttribute getCohortMemberAttributeByUuid(String uuid) {
+		return attributeDao.getCohortMemberAttributeByUuid(uuid);
+	}
+	
+	@Override
+	public List<CohortMemberAttribute> getCohortMemberAttributeByTypeUuid(String attributeTypeUuid) {
+		return attributeDao.getCohortMemberAttributesByTypeUuid(attributeTypeUuid);
+	}
+	
+	@Override
+	public CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
+		return attributeDao.saveCohortMemberAttribute(cohortMemberAttribute);
+	}
+	
+	@Override
+	public void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
+		attributeDao.purgeCohortMemberAttribute(cohortMemberAttribute);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -60,7 +60,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	public CohortDAO getDao() {
 		return dao;
 	}
- 
+	
 	/**
 	 * @param dao the dao to set
 	 */
@@ -147,7 +147,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	public List<CohortM> findCohortsMatching(String nameMatching, Map<String, String> attributes, CohortType cohortType) {
 		return dao.findCohorts(nameMatching, attributes, cohortType);
 	}
- 
+	
 	@Override
 	public CohortAttribute saveCohortAttribute(CohortAttribute att) {
 		return dao.saveCohortAttributes(att);
@@ -268,7 +268,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	public void purgeCohortObs(CohortObs cobs) {
 		dao.purgeCohortObs(cobs);
 	}
-
+	
 	@Override
 	public CohortObs getCohortObsById(Integer id) {
 		return dao.findCohortObs(id);
@@ -295,24 +295,18 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public List<CohortEncounter> getEncounters(CohortM who, Location loc,
-			Date fromDate, Date toDate, Collection<Form> enteredViaForms,
-			Collection<EncounterType> encounterTypes, boolean includeVoided) {
-		return Context.getService(CohortService.class).getEncounters(who, loc, fromDate, toDate, enteredViaForms, encounterTypes, null, includeVoided);
+	public List<CohortEncounter> getEncounters(CohortM who, Location loc, Date fromDate, Date toDate,
+	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, boolean includeVoided) {
+		return Context.getService(CohortService.class).getEncounters(who, loc, fromDate, toDate, enteredViaForms,
+		    encounterTypes, null, includeVoided);
 	}
 	
 	public List<CohortEncounter> getEncounters(CohortM who, Location loc, Date fromDate, Date toDate,
-			Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<User> providers,
-			boolean includeVoided) {
-		EncounterSearchCriteriaBuilder encounterSearchCriteriaBuilder = new EncounterSearchCriteriaBuilder()
-				.setCohort(who)
-				.setLocation(loc)
-				.setFromDate(fromDate)
-				.setToDate(toDate)
-				.setEnteredViaForms(enteredViaForms)
-				.setEncounterTypes(encounterTypes)
-				.setProviders(usersToProviders(providers))
-				.setIncludeVoided(includeVoided);
+	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<User> providers,
+	        boolean includeVoided) {
+		EncounterSearchCriteriaBuilder encounterSearchCriteriaBuilder = new EncounterSearchCriteriaBuilder().setCohort(who)
+		        .setLocation(loc).setFromDate(fromDate).setToDate(toDate).setEnteredViaForms(enteredViaForms)
+		        .setEncounterTypes(encounterTypes).setProviders(usersToProviders(providers)).setIncludeVoided(includeVoided);
 		return getEncounters(encounterSearchCriteriaBuilder.createEncounterSearchCriteria());
 	}
 	
@@ -328,10 +322,11 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 		return ret;
 	}
 	
-	public List<CohortEncounter> getEncounters(org.openmrs.module.cohort.api.db.EncounterSearchCriteria encounterSearchCriteria) {
+	public List<CohortEncounter> getEncounters(
+	        org.openmrs.module.cohort.api.db.EncounterSearchCriteria encounterSearchCriteria) {
 		// the second search parameter is null as it defaults to authenticated user from context
-		return Context.getService(CohortService.class).filterEncountersByViewPermissions(dao.getEncounters(encounterSearchCriteria),
-				null);
+		return Context.getService(CohortService.class)
+		        .filterEncountersByViewPermissions(dao.getEncounters(encounterSearchCriteria), null);
 	}
 	
 	public List<CohortEncounter> filterEncountersByViewPermissions(List<CohortEncounter> encounters, User user) {
@@ -340,7 +335,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 			if (user == null) {
 				user = Context.getAuthenticatedUser();
 			}
-			for (Iterator<CohortEncounter> iterator = encounters.iterator(); iterator.hasNext(); ) {
+			for (Iterator<CohortEncounter> iterator = encounters.iterator(); iterator.hasNext();) {
 				CohortEncounter encounter = iterator.next();
 				// determine whether it's need to include this encounter into result or not
 				// as it can be not accessed by current user due to permissions lack
@@ -360,8 +355,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public List<CohortObs> getObservationsByCohortAndConcept(CohortM who,
-			Concept question) {
+	public List<CohortObs> getObservationsByCohortAndConcept(CohortM who, Concept question) {
 		List<CohortM> whom = new Vector<>();
 		if (who != null && who.getCohortId() != null) {
 			whom.add(who);
@@ -369,15 +363,14 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 		List<Concept> questions = new Vector<>();
 		questions.add(question);
 		
-		return Context.getService(CohortService.class).getObservations(whom, null, questions, null, null, null, null, null, null, null, false);
+		return Context.getService(CohortService.class).getObservations(whom, null, questions, null, null, null, null, null,
+		    null, null, false);
 	}
 	
 	@Override
-	public List<CohortObs> getObservations(List<CohortM> whom,
-			List<CohortEncounter> encounters, List<Concept> questions,
-			List<Concept> answers, List<Location> locations, List<String> sort,
-			Integer mostRecentN, Integer obsGroupId, Date fromDate,
-			Date toDate, boolean includeVoidedObs) {
+	public List<CohortObs> getObservations(List<CohortM> whom, List<CohortEncounter> encounters, List<Concept> questions,
+	        List<Concept> answers, List<Location> locations, List<String> sort, Integer mostRecentN, Integer obsGroupId,
+	        Date fromDate, Date toDate, boolean includeVoidedObs) {
 		return null;
 	}
 	
@@ -395,7 +388,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	public Long getCount(String name) {
 		return dao.getCount(name);
 	}
- 
+	
 	@Override
 	public CohortObs voidObs(CohortObs obs, String reason) {
 		return dao.saveObs(obs);
@@ -417,136 +410,136 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public List<CohortMember> findCohortMembersByCohort (Integer cohortId) {
+	public List<CohortMember> findCohortMembersByCohort(Integer cohortId) {
 		return dao.findCohortMembersByCohortId(cohortId);
 	}
-
+	
 	/*@Override
 	public List<CohortM> getCohortsByLocationId(Integer id) {
 		return dao.getCohortsByLocationId(id);
 	}
-
+	
 	@Override
 	public List<CohortM> getCohortByCohortTypeId(Integer id) {
 		return dao.getCohortByCohortTypeId(id);
 	}
-
+	
 	@Override
 	public List<CohortM> getCohortByCohortProgramId(Integer id) {
 		return dao.getCohortByCohortProgramId(id);
 	}*/
-
+	
 	@Override
 	public List<CohortMember> getCohortMembersByCohortRoleId(Integer id) {
 		return dao.getCohortMembersByCohortRoleId(id);
 	}
-
+	
 	@Override
-	public CohortM getCohort(Integer locationId, Integer programId,Integer typeId) {
+	public CohortM getCohort(Integer locationId, Integer programId, Integer typeId) {
 		return dao.getCohort(locationId, programId, typeId);
 	}
-
+	
 	@Override
 	public List<CohortMember> getCohortMembersByCohortId(Integer id) {
 		return dao.getCohortMembersByCohortId(id);
 	}
-
+	
 	@Override
 	public List<CohortRole> getAllCohortRoles() {
 		return dao.getAllCohortRoles();
 	}
-
+	
 	@Override
 	public CohortRole getCohortRoleByName(String name) {
 		return dao.getCohortRoleByName(name);
 	}
-
+	
 	@Override
 	public List<CohortAttribute> findCohortAttributes(Integer cohortId, Integer attributeTypeId) {
 		return dao.findCohortAttributes(cohortId, attributeTypeId);
 	}
-
+	
 	@Override
 	public CohortType getCohortTypeByName(String name) {
 		return dao.getCohortTypeByName(name);
 	}
-
+	
 	@Override
 	public CohortM getCohortByName(String name) {
 		return dao.getCohortByName(name);
 	}
-
+	
 	@Override
 	public List<CohortVisit> getCohortVisitsByLocation(Integer id) {
 		return dao.getCohortVisitsByLocationId(id);
 	}
-
+	
 	@Override
 	public List<CohortMember> getAllHeadCohortMembers() {
 		return dao.getAllHeadCohortMembers();
 	}
-
+	
 	@Override
 	public List<CohortObs> getCohortObsByEncounterId(Integer id) {
 		return dao.getCohortObsByEncounterId(id);
 	}
-
+	
 	@Override
 	public List<CohortVisit> getCohortVisitsByDate(Date startDate, Date endDate) {
 		return dao.getCohortVisitsByDate(startDate, endDate);
 	}
-
+	
 	@Override
 	public CohortLeader getCohortLeaderByUuid(String uuid) {
 		return dao.getCohortLeaderByUuid(uuid);
 	}
-
+	
 	@Override
 	public CohortLeader getCohortLeaderById(Integer id) {
 		return dao.getCohortLeaderById(id);
 	}
-
+	
 	@Override
 	public List<CohortLeader> getCohortLeadersByCohortId(Integer id) {
 		return dao.getCohortLeadersByCohortId(id);
 	}
-
+	
 	@Override
 	public CohortLeader saveCohortLeader(CohortLeader cohortLeader) {
 		return dao.saveCohortLeader(cohortLeader);
 	}
-
+	
 	@Override
 	public CohortLeader voidCohortLeader(CohortLeader cohortLeader, String reason) {
 		return dao.saveCohortLeader(cohortLeader);
 	}
-
-
+	
 	@Override
 	public void purgeCohortLeader(CohortLeader cohortLeader) {
-			dao.purgeCohortLeader(cohortLeader);
+		dao.purgeCohortLeader(cohortLeader);
 	}
-
+	
 	@Override
 	public CohortMemberVisit getCohortMemberVisitByUuid(String uuid) {
 		return dao.getCohortMemberVisitByUuid(uuid);
 	}
+	
 	public List<CohortMember> findCohortMembersByPatient(int patientId) {
 		return dao.getCohortMembersByPatientId(patientId);
 	}
-
-
+	
 	@Override
 	public CohortMemberVisit saveCohortMemberVisit(CohortMemberVisit cohortMemberVisit) {
 		return dao.saveCohortMemberVisit(cohortMemberVisit);
 	}
-    @Override
-    public List<CohortAttribute> getCohortAttributesByAttributeType(Integer attributeTypeId) {
-        return dao.getCohortAttributesByAttributeType(attributeTypeId);
-    }
- 
-    @Override
-    public List<CohortM> getCohortsByLocationId(int locationId) {
-        return dao.getCohortsByLocationId(locationId);
-    }
+	
+	@Override
+	public List<CohortAttribute> getCohortAttributesByAttributeType(Integer attributeTypeId) {
+		return dao.getCohortAttributesByAttributeType(attributeTypeId);
+	}
+	
+	@Override
+	public List<CohortM> getCohortsByLocationId(int locationId) {
+		return dao.getCohortsByLocationId(locationId);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -1,15 +1,11 @@
-/**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.cohort.api.impl;
 

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortAttributeTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortAttributeTypeValidator.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.validator;
 
 import org.openmrs.module.cohort.CohortAttributeType;

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortAttributeTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortAttributeTypeValidator.java
@@ -10,18 +10,18 @@ import org.springframework.validation.Validator;
 @Component
 @Qualifier("addCohortAttributeTypeValidator")
 public class AddCohortAttributeTypeValidator implements Validator {
-
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return clazz.equals(CohortAttributeType.class);
-    }
-
-    @Override
-    public void validate(Object command, Errors errors) {
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "format", "required");
-        
-        //TODO reject if duplicate is created
-    }
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return clazz.equals(CohortAttributeType.class);
+	}
+	
+	@Override
+	public void validate(Object command, Errors errors) {
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "format", "required");
+		
+		//TODO reject if duplicate is created
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortProgramValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortProgramValidator.java
@@ -12,26 +12,26 @@ import org.springframework.validation.Validator;
 @Component
 @Qualifier("addCohortProgramValidator")
 public class AddCohortProgramValidator implements Validator {
-
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return clazz.equals(CohortProgram.class);
-    }
-
-    @Override
-    public void validate(Object command, Errors errors) {
-    	CohortService cohortService = Context.getService(CohortService.class);
-
-    	ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
-        
-        CohortProgram program = (CohortProgram) command;
-
-        // TODO change it to find by name and then reject
-        for (CohortProgram programs : cohortService.getAllCohortPrograms()) {
-            if (program.getName().equals(programs.getName())) {
-            	errors.rejectValue("name", "An entry with this name already exists");
-            }
-        }
-    }
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return clazz.equals(CohortProgram.class);
+	}
+	
+	@Override
+	public void validate(Object command, Errors errors) {
+		CohortService cohortService = Context.getService(CohortService.class);
+		
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
+		
+		CohortProgram program = (CohortProgram) command;
+		
+		// TODO change it to find by name and then reject
+		for (CohortProgram programs : cohortService.getAllCohortPrograms()) {
+			if (program.getName().equals(programs.getName())) {
+				errors.rejectValue("name", "An entry with this name already exists");
+			}
+		}
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortProgramValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortProgramValidator.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.validator;
 
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortRoleValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortRoleValidator.java
@@ -12,23 +12,23 @@ import org.springframework.validation.Validator;
 @Component
 @Qualifier("addCohortRoleValidator")
 public class AddCohortRoleValidator implements Validator {
-
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return clazz.equals(CohortRole.class);
-    }
-
-    @Override
-    public void validate(Object command, Errors errors) {
-        CohortService cohortService = Context.getService(CohortService.class);
-        
-        CohortRole currentRole = (CohortRole) command;
-        CohortRole role = cohortService.getCohortRoleByName(currentRole.getName());
-        
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
-
-        if (role != null) {
-        	errors.rejectValue("name", "An entry with this name already exists");
-        }
-    }
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return clazz.equals(CohortRole.class);
+	}
+	
+	@Override
+	public void validate(Object command, Errors errors) {
+		CohortService cohortService = Context.getService(CohortService.class);
+		
+		CohortRole currentRole = (CohortRole) command;
+		CohortRole role = cohortService.getCohortRoleByName(currentRole.getName());
+		
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
+		
+		if (role != null) {
+			errors.rejectValue("name", "An entry with this name already exists");
+		}
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortRoleValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortRoleValidator.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.validator;
 
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortTypeValidator.java
@@ -12,24 +12,24 @@ import org.springframework.validation.Validator;
 @Component
 @Qualifier("addCohortTypeValidator")
 public class AddCohortTypeValidator implements Validator {
-
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return clazz.equals(CohortType.class);
-    }
-
-    @Override
-    public void validate(Object command, Errors errors) {
-    	CohortService cohortService = Context.getService(CohortService.class);
-
-    	ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
-        
-        CohortType currentType = (CohortType) command;
-        CohortType type = cohortService.getCohortTypeByName(currentType.getName());
-        
-        if (type != null) {
-        	errors.rejectValue("name", "a cohort type with the same name already exists");
-        }
-    }
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return clazz.equals(CohortType.class);
+	}
+	
+	@Override
+	public void validate(Object command, Errors errors) {
+		CohortService cohortService = Context.getService(CohortService.class);
+		
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
+		
+		CohortType currentType = (CohortType) command;
+		CohortType type = cohortService.getCohortTypeByName(currentType.getName());
+		
+		if (type != null) {
+			errors.rejectValue("name", "a cohort type with the same name already exists");
+		}
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortTypeValidator.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.validator;
 
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortValidator.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.validator;
 
 import java.util.List;

--- a/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validator/AddCohortValidator.java
@@ -14,32 +14,32 @@ import org.springframework.validation.Validator;
 @Component
 @Qualifier("addCohortValidator")
 public class AddCohortValidator implements Validator {
-
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return clazz.equals(CohortM.class);
-    }
-
-    @Override
-    public void validate(Object command, Errors errors) {
-    	CohortService service = Context.getService(CohortService.class);
-
-    	ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "Cohort Name Required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "Cohort Description Required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "startDate", "Cohort Start Date Required");
-        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "endDate", "Cohort End Date Required");
-        
-        CohortM cohort = (CohortM) command;
-        if (cohort.getStartDate().compareTo(cohort.getEndDate()) > 0) {
-        	errors.rejectValue("startDate", "Start date should be less than End date");
-        }
-        
-        // TODO change it to find by name and then reject
-        List<CohortM> allCohorts = service.getAllCohorts();
-        for (CohortM checkCohort : allCohorts) {
-            if (checkCohort.getName().equals(cohort.getName())) {
-            	errors.rejectValue("name", "A cohort with this name already exists");
-            }
-        }
-    }
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return clazz.equals(CohortM.class);
+	}
+	
+	@Override
+	public void validate(Object command, Errors errors) {
+		CohortService service = Context.getService(CohortService.class);
+		
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "Cohort Name Required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "Cohort Description Required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "startDate", "Cohort Start Date Required");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "endDate", "Cohort End Date Required");
+		
+		CohortM cohort = (CohortM) command;
+		if (cohort.getStartDate().compareTo(cohort.getEndDate()) > 0) {
+			errors.rejectValue("startDate", "Start date should be less than End date");
+		}
+		
+		// TODO change it to find by name and then reject
+		List<CohortM> allCohorts = service.getAllCohorts();
+		for (CohortM checkCohort : allCohorts) {
+			if (checkCohort.getName().equals(cohort.getName())) {
+				errors.rejectValue("name", "A cohort with this name already exists");
+			}
+		}
+	}
 }

--- a/api/src/main/resources/CohortMemberAttribute.hbm.xml
+++ b/api/src/main/resources/CohortMemberAttribute.hbm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
@@ -8,7 +7,6 @@
 
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
-
 -->
 <!DOCTYPE hibernate-mapping PUBLIC
         "-//Hibernate/Hibernate Mapping DTD 3.0//EN"

--- a/api/src/main/resources/CohortMemberAttributeType.hbm.xml
+++ b/api/src/main/resources/CohortMemberAttributeType.hbm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
@@ -8,7 +7,6 @@
 
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
-
 -->
 <!DOCTYPE hibernate-mapping PUBLIC
         "-//Hibernate/Hibernate Mapping DTD 3.0//EN"

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
 
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/api/src/main/resources/log4j.properties
+++ b/api/src/main/resources/log4j.properties
@@ -1,3 +1,13 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+
 log4j.logger.org.hibernate=INFO, hb
 log4j.logger.org.hibernate.SQL=DEBUG
 log4j.logger.org.hibernate.type=TRACE

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,3 +1,13 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+
 ${project.parent.artifactId}.title=Cohort Module
 ${project.parent.artifactId}.manage=Manage module
 ${project.parent.artifactId}.cohortname=Cohort Name

--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -1,1 +1,11 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+
 

--- a/api/src/main/resources/messages_fr.properties
+++ b/api/src/main/resources/messages_fr.properties
@@ -1,0 +1,10 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"

--- a/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
@@ -21,8 +21,8 @@ import org.openmrs.module.cohort.CohortMemberAttributeType;
 import org.openmrs.module.cohort.CohortType;
 
 public class TestDataUtils {
-
-	public static CohortType COHORT_TYPE () {
+	
+	public static CohortType COHORT_TYPE() {
 		CohortType cohortType = new CohortType();
 		cohortType.setId(1);
 		cohortType.setCohortTypeId(100);
@@ -30,7 +30,7 @@ public class TestDataUtils {
 		cohortType.setDescription("Test cohort description");
 		return cohortType;
 	}
-
+	
 	public static CohortAttributeType COHORT_ATTRIBUTE_TYPE() {
 		CohortAttributeType cohortAttributeType = new CohortAttributeType();
 		cohortAttributeType.setId(1);
@@ -40,8 +40,8 @@ public class TestDataUtils {
 		cohortAttributeType.setCohortAttributeTypeId(400);
 		return cohortAttributeType;
 	}
-
-	public static CohortAttribute COHORT_ATTRIBUTE () {
+	
+	public static CohortAttribute COHORT_ATTRIBUTE() {
 		CohortAttribute cohortAttribute = new CohortAttribute();
 		cohortAttribute.setId(1);
 		cohortAttribute.setUuid("");
@@ -50,7 +50,7 @@ public class TestDataUtils {
 		cohortAttribute.setCohortAttributeType(COHORT_ATTRIBUTE_TYPE());
 		return cohortAttribute;
 	}
-
+	
 	public static CohortMemberAttributeType COHORT_MEMBER_ATTRIBUTE_TYPE() {
 		CohortMemberAttributeType cohortMemberAttributeType = new CohortMemberAttributeType();
 		cohortMemberAttributeType.setId(1);
@@ -60,8 +60,8 @@ public class TestDataUtils {
 		cohortMemberAttributeType.setDatatypeClassname("java.lang.String");
 		return cohortMemberAttributeType;
 	}
-
-	public static CohortMemberAttribute COHORT_MEMBER_ATTRIBUTE () {
+	
+	public static CohortMemberAttribute COHORT_MEMBER_ATTRIBUTE() {
 		CohortMemberAttribute cohortMemberAttribute = new CohortMemberAttribute();
 		cohortMemberAttribute.setId(1);
 		cohortMemberAttribute.setUuid("32816782-d578-401c-8475-8ccbb26ce001");
@@ -70,7 +70,7 @@ public class TestDataUtils {
 		cohortMemberAttribute.setId(100);
 		return cohortMemberAttribute;
 	}
-
+	
 	public static CohortM COHORT() {
 		CohortM cohort = new CohortM();
 		cohort.setCohortId(1);
@@ -80,7 +80,7 @@ public class TestDataUtils {
 		cohort.setCohortLeaders(Collections.singletonList(COHORT_LEADER()));
 		return cohort;
 	}
-
+	
 	public static CohortLeader COHORT_LEADER() {
 		CohortLeader leader = new CohortLeader();
 		leader.setId(1);
@@ -91,5 +91,5 @@ public class TestDataUtils {
 		leader.setEndDate(new Date());
 		return leader;
 	}
-
+	
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/TestSpringConfiguration.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/TestSpringConfiguration.java
@@ -13,5 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 @Configuration
-@ImportResource({ "classpath:applicationContext-service.xml", "classpath:moduleApplicationContext.xml", "classpath:TestApplicationContext.xml" })
+@ImportResource({ "classpath:applicationContext-service.xml", "classpath:moduleApplicationContext.xml",
+        "classpath:TestApplicationContext.xml" })
 public class TestSpringConfiguration {}

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortAttributeDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortAttributeDaoTest.java
@@ -31,39 +31,39 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortAttributeDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_ATTRIBUTE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_ATTRIBUTE_UUID = "ddadadd8-8034-4a28-9441-2eb2e7679e10";
-
+	
 	private static final int COHORT_ATTRIBUTE_ID = 1;
-
+	
 	private static final String TEST_COHORT_ATTRIBUTE = "Test cohort attribute";
-
+	
 	private static final int TEST_COHORT_ATTRIBUTE_ID = 200;
-
+	
 	private static final String COHORT_ATTRIBUTE_VALUE = "cohortAttribute";
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_ATTRIBUTE_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void getCohortAttributeById_shouldGetCohortAttributeById() {
 		CohortAttribute cohortAttribute = dao.getCohortAttributeById(COHORT_ATTRIBUTE_ID);
 		assertThat(cohortAttribute, notNullValue());
 		assertThat(cohortAttribute.getCohortAttributeId(), equalTo(COHORT_ATTRIBUTE_ID));
 	}
-
+	
 	@Test
 	public void getCohortAttributeByUuid_shouldGetCohortAttributeByUuid() {
 		CohortAttribute cohortAttribute = dao.getCohortAttributeByUuid(COHORT_ATTRIBUTE_UUID);
@@ -71,7 +71,7 @@ public class CohortAttributeDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortAttribute.getCohortAttributeId(), equalTo(COHORT_ATTRIBUTE_ID));
 		assertThat(cohortAttribute.getUuid(), equalTo(COHORT_ATTRIBUTE_UUID));
 	}
-
+	
 	@Test
 	public void saveCohortAttributes_shouldCreateNewCohortAttribute() {
 		CohortAttribute cohortAttribute = dao.saveCohortAttributes(TestDataUtils.COHORT_ATTRIBUTE());
@@ -80,12 +80,12 @@ public class CohortAttributeDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortAttribute.getCohortAttributeId(), equalTo(TEST_COHORT_ATTRIBUTE_ID));
 		assertThat(cohortAttribute.getValue(), equalTo(COHORT_ATTRIBUTE_VALUE));
 	}
-
+	
 	@Test
 	public void findCohortAttributes_shouldFindMatchingCohortAttributes() {
 		List<CohortAttribute> results = dao.findCohortAttribute(TEST_COHORT_ATTRIBUTE);
 		assertThat(results, notNullValue());
-		assertThat(results, not(Matchers.<CohortAttribute>empty()));
-		assertThat(results, Matchers.<CohortAttribute>hasSize(equalTo(1)));
+		assertThat(results, not(Matchers.<CohortAttribute> empty()));
+		assertThat(results, Matchers.<CohortAttribute> hasSize(equalTo(1)));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortAttributeTypeDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortAttributeTypeDaoTest.java
@@ -27,26 +27,26 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortAttributeTypeDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
-
+	
 	private static final int COHORT_ATTRIBUTE_TYPE_ID = 1;
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldGetCohortAttributeTypeById() {
 		CohortAttributeType cohortAttributeType = dao.getCohortAttributeTypeById(COHORT_ATTRIBUTE_TYPE_ID);
@@ -54,7 +54,7 @@ public class CohortAttributeTypeDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), notNullValue());
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), equalTo(COHORT_ATTRIBUTE_TYPE_ID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortAttributeTypeByUuid() {
 		CohortAttributeType cohortAttributeType = dao.getCohortAttributeTypeByUuid(COHORT_ATTRIBUTE_TYPE_UUID);
@@ -63,7 +63,7 @@ public class CohortAttributeTypeDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), equalTo(COHORT_ATTRIBUTE_TYPE_ID));
 		assertThat(cohortAttributeType.getUuid(), equalTo(COHORT_ATTRIBUTE_TYPE_UUID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortAttributes() {
 		CohortAttributeType cohortAttributeType = dao.getCohortAttributes(COHORT_ATTRIBUTE_TYPE_ID);
@@ -71,14 +71,15 @@ public class CohortAttributeTypeDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), notNullValue());
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), equalTo(COHORT_ATTRIBUTE_TYPE_ID));
 	}
-
+	
 	@Test
 	public void saveCohortAttributes() {
 		CohortAttributeType cohortAttributeType = dao.saveCohortAttributes(TestDataUtils.COHORT_ATTRIBUTE_TYPE());
 		assertThat(cohortAttributeType, notNullValue());
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), notNullValue());
-		assertThat(cohortAttributeType.getCohortAttributeTypeId(), equalTo(TestDataUtils.COHORT_ATTRIBUTE_TYPE().getCohortAttributeTypeId()));
-
+		assertThat(cohortAttributeType.getCohortAttributeTypeId(),
+		    equalTo(TestDataUtils.COHORT_ATTRIBUTE_TYPE().getCohortAttributeTypeId()));
+		
 		CohortAttributeType result = dao.getCohortAttributeTypeById(cohortAttributeType.getId());
 		assertThat(result, notNullValue());
 		assertThat(result.getCohortAttributeTypeId(), notNullValue());

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortDaoTest.java
@@ -28,32 +28,32 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_UUID = "7f9a2479-c14a-4bfc-bcaa-632860258519";
-
+	
 	private static final String COHORT_NAME = "COVID-19 patients";
-
+	
 	private static final int COHORT_ID = 12;
-
+	
 	private static final String COHORT_NAME1 = "cohort name";
-
+	
 	private static final String COHORT_DESCRIPTION = "Cohort description";
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldGetCohortByName() {
 		CohortM cohort = dao.getCohortByName(COHORT_NAME);
@@ -61,7 +61,7 @@ public class CohortDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohort.getName(), notNullValue());
 		assertThat(cohort.getName(), equalTo(COHORT_NAME));
 	}
-
+	
 	@Test
 	public void shouldGetCohortMById() {
 		CohortM cohort = dao.getCohortMById(COHORT_ID);
@@ -69,7 +69,7 @@ public class CohortDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohort.getCohortId(), notNullValue());
 		assertThat(cohort.getCohortId(), equalTo(COHORT_ID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortMByUuid() {
 		CohortM cohort = dao.getCohortMByUuid(COHORT_UUID);
@@ -79,7 +79,7 @@ public class CohortDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohort.getUuid(), notNullValue());
 		assertThat(cohort.getUuid(), equalTo(COHORT_UUID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortUuid() {
 		CohortM cohort = dao.getCohortUuid(COHORT_UUID);
@@ -87,7 +87,7 @@ public class CohortDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohort.getUuid(), notNullValue());
 		assertThat(cohort.getUuid(), equalTo(COHORT_UUID));
 	}
-
+	
 	@Test
 	public void shouldCreateNewCohort() {
 		CohortM cohortM = new CohortM();
@@ -97,13 +97,13 @@ public class CohortDaoTest extends BaseModuleContextSensitiveTest {
 		cohortM.setDescription(COHORT_DESCRIPTION);
 		CohortM cohort = dao.saveCohort(cohortM);
 		assertThat(cohort, notNullValue());
-
+		
 		CohortM savedCohort = dao.getCohortMById(cohort.getCohortId());
 		assertThat(savedCohort, notNullValue());
 		assertThat(savedCohort, equalTo(cohort));
-
+		
 	}
-
+	
 	@Test
 	public void shouldGetCohortWhereLocationProgramAndTypeAreNull() {
 		CohortM cohort = dao.getCohort(null, null, null);

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortLeaderDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortLeaderDaoTest.java
@@ -31,28 +31,28 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortLeaderDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_LEADER_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortLeaderDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_LEADER_UUID = "3f9a2479-c14a-4bfc-bcaa-632860258518";
-
+	
 	private static final int COHORT_LEADER_ID = 123;
-
+	
 	private static final int COHORT_ID = 1;
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_LEADER_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldGetCohortLeaderByUuid() {
 		CohortLeader cohortLeader = dao.getCohortLeaderByUuid(COHORT_LEADER_UUID);
@@ -60,7 +60,7 @@ public class CohortLeaderDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortLeader.getUuid(), notNullValue());
 		assertThat(cohortLeader.getUuid(), equalTo(COHORT_LEADER_UUID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortLeaderById() {
 		CohortLeader cohortLeader = dao.getCohortLeaderById(COHORT_LEADER_ID);
@@ -68,15 +68,15 @@ public class CohortLeaderDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortLeader.getCohortLeaderId(), notNullValue());
 		assertThat(cohortLeader.getCohortLeaderId(), equalTo(COHORT_LEADER_ID));
 	}
-
+	
 	@Test
 	public void shouldGetCohortLeadersByCohortId() {
 		List<CohortLeader> cohortLeader = dao.getCohortLeadersByCohortId(COHORT_ID);
 		assertThat(cohortLeader, notNullValue());
-		assertThat(cohortLeader, Matchers.<CohortLeader>hasSize(greaterThanOrEqualTo(1)));
+		assertThat(cohortLeader, Matchers.<CohortLeader> hasSize(greaterThanOrEqualTo(1)));
 		assertThat(cohortLeader.get(0).getCohort().getCohortId(), equalTo(COHORT_ID));
 	}
-
+	
 	@Test
 	public void shouldCreateCohortLeader() {
 		CohortLeader cohortLeader = new CohortLeader();
@@ -86,7 +86,7 @@ public class CohortLeaderDaoTest extends BaseModuleContextSensitiveTest {
 		CohortLeader result = dao.saveCohortLeader(cohortLeader);
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), equalTo(321));
-
+		
 		CohortLeader savedCohortLeader = dao.getCohortLeaderById(321);
 		assertThat(savedCohortLeader, notNullValue());
 		assertThat(savedCohortLeader, equalTo(cohortLeader));

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortProgramDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortProgramDaoTest.java
@@ -27,41 +27,41 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortProgramDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_PROGRAM_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortProgramDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_PROGRAM_UUID = "94517bf9-d8d7-4726-b4f1-a2dff6b36e2d";
-
+	
 	private static final String BAD_COHORT_PROGRAM_UUID = "xx0a2479-c55a-4bfc-bb99-632860xx8518";
-
+	
 	private static final int COHORT_PROGRAM_ID = 102;
-
+	
 	private static final int BAD_COHORT_PROGRAM_ID = -1;
-
+	
 	private static final String COHORT_PROGRAM_NAME = "cohort program name";
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_PROGRAM_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldFindCohortProgramByID() {
 		CohortProgram cohortProgram = dao.getCohortProgramById(COHORT_PROGRAM_ID);
 		assertThat(cohortProgram, notNullValue());
 		assertThat(cohortProgram.getCohortProgramId(), equalTo(COHORT_PROGRAM_ID));
 		assertThat(cohortProgram.getName(), equalTo(COHORT_PROGRAM_NAME));
-
+		
 	}
-
+	
 	@Test
 	public void shouldFindCohortProgramByUuid() {
 		CohortProgram cohortProgram = dao.getCohortProgramByUuid(COHORT_PROGRAM_UUID);
@@ -69,20 +69,20 @@ public class CohortProgramDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortProgram.getUuid(), notNullValue());
 		assertThat(cohortProgram.getName(), equalTo(COHORT_PROGRAM_NAME));
 		assertThat(cohortProgram.getUuid(), equalTo(COHORT_PROGRAM_UUID));
-
+		
 	}
-
+	
 	@Test
 	public void shouldReturnNullWhenFindCohortProgramByBadUuid() {
 		CohortProgram cohortProgram = dao.getCohortProgramByUuid(BAD_COHORT_PROGRAM_UUID);
 		assertThat(cohortProgram, nullValue());
-
+		
 	}
-
+	
 	@Test
 	public void shouldReturnNullWhenFindCohortProgramByBadId() {
 		CohortProgram cohortProgram = dao.getCohortProgramById(BAD_COHORT_PROGRAM_ID);
 		assertThat(cohortProgram, nullValue());
-
+		
 	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortRoleDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortRoleDaoTest.java
@@ -30,44 +30,44 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortRoleDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_ROLE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortRoleDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_ROLE_UUID = "3f9a2479-c14a-4bfc-bcaa-632860258518";
-
+	
 	private static final int COHORT_ROLE_ID = 1;
-
+	
 	private static final String COHORT_ROLE_NAME = "test cohort role";
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_ROLE_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldFindCohortRoleByID() {
 		CohortRole cohortRole = dao.getCohortRoleById(COHORT_ROLE_ID);
 		assertThat(cohortRole, notNullValue());
 		assertThat(cohortRole.getCohortRoleId(), equalTo(COHORT_ROLE_ID));
-
+		
 	}
-
+	
 	@Test
 	public void shouldFindCohortRoleByUuid() {
 		CohortRole cohortRole = dao.getCohortRoleByUuid(COHORT_ROLE_UUID);
 		assertThat(cohortRole, notNullValue());
 		assertThat(cohortRole.getUuid(), equalTo(COHORT_ROLE_UUID));
-
+		
 	}
-
+	
 	@Test
 	public void shouldFindCohortRoleByName() {
 		CohortRole cohortRole = dao.getCohortRoleByName(COHORT_ROLE_NAME);
@@ -75,12 +75,12 @@ public class CohortRoleDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(cohortRole.getName(), notNullValue());
 		assertThat(cohortRole.getName(), equalTo(COHORT_ROLE_NAME));
 	}
-
+	
 	@Test
 	public void shouldFindAllCohortRoles() {
 		List<CohortRole> cohortRoles = dao.findCohortRoles(COHORT_ROLE_NAME);
 		assertThat(cohortRoles, notNullValue());
-		assertThat(cohortRoles, Matchers.<CohortRole>hasSize(greaterThanOrEqualTo(1)));
+		assertThat(cohortRoles, Matchers.<CohortRole> hasSize(greaterThanOrEqualTo(1)));
 		assertThat(cohortRoles.get(0).getName(), equalTo(COHORT_ROLE_NAME));
 		assertThat(cohortRoles.get(0).getUuid(), equalTo(COHORT_ROLE_UUID));
 	}

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/CohortTypeDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/CohortTypeDaoTest.java
@@ -26,51 +26,51 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortTypeDaoTest extends BaseModuleContextSensitiveTest {
-
+	
 	private static final String COHORT_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortTypeDaoTest_initialTestData.xml";
-
+	
 	private static final String COHORT_TYPE_UUID = "94517bf9-d8d7-4726-b4f1-a2dff6b36e2d";
-
+	
 	private static final int COHORT_TYPE_ID = 101;
-
+	
 	private static final String COHORT_TYPE_NAME = "cohort type name";
-
+	
 	private HibernateCohortDAO dao;
-
+	
 	@Autowired
 	@Qualifier("sessionFactory")
 	private SessionFactory sessionFactory;
-
+	
 	@Before
 	public void setup() throws Exception {
 		dao = new HibernateCohortDAO();
 		dao.setSessionFactory(sessionFactory);
 		executeDataSet(COHORT_TYPE_INITIAL_TEST_DATA_XML);
 	}
-
+	
 	@Test
 	public void shouldFindCohortTypeByID() {
 		CohortType cohortType = dao.getCohortTypeById(COHORT_TYPE_ID);
 		assertThat(cohortType, notNullValue());
 		assertThat(cohortType.getCohortTypeId(), equalTo(COHORT_TYPE_ID));
-
+		
 	}
-
+	
 	@Test
 	public void shouldFindCohortTypeByUuid() {
 		CohortType cohortType = dao.getCohortTypeByUuid(COHORT_TYPE_UUID);
 		assertThat(cohortType, notNullValue());
 		assertThat(cohortType.getUuid(), equalTo(COHORT_TYPE_UUID));
-
+		
 	}
-
+	
 	@Test
 	public void shouldFindCohortTypeByName() {
 		CohortType cohortType = dao.getCohortTypeByName(COHORT_TYPE_NAME);
 		assertThat(cohortType, notNullValue());
 		assertThat(cohortType.getUuid(), equalTo(COHORT_TYPE_UUID));
 		assertThat(cohortType.getName(), equalTo(COHORT_TYPE_NAME));
-
+		
 	}
-
+	
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeDaoTest.java
@@ -9,6 +9,15 @@
  */
 package org.openmrs.module.cohort.api.db.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,90 +29,81 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortMemberAttributeDaoTest extends BaseModuleContextSensitiveTest {
-
-    //The order is salient
-    private static final String[] COHORT_MEMBER_ATTRIBUTE_INITIAL_TEST_DATA_XML = new String[]{
-            "org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml",
-            "org/openmrs/module/cohort/api/hibernate/db/CohortMemberDaoTest_initialTestData.xml",
-            "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml",
-            "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeDaoTest_initialTestData.xml"
-    };
-
-    private static final String COHORT_MEMBER_ATTRIBUTE_UUID = "ddadadd8-8034-4a28-9441-2eb2e7679e10";
-
-    private static final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
-
-    private static final int COHORT_MEMBER_ATTRIBUTE_ID = 1;
-
-    private static final int TEST_COHORT_MEMBER_ATTRIBUTE_ID = 100;
-
-    private static final String COHORT_MEMBER_ATTRIBUTE_VALUE = "cohortMemberAttribute";
-
-    private CohortMemberAttributeDaoImpl dao;
-
-    @Autowired
-    @Qualifier("sessionFactory")
-    private SessionFactory sessionFactory;
-
-    @Before
-    public void setup() throws Exception {
-        dao = new CohortMemberAttributeDaoImpl();
-        dao.setSessionFactory(sessionFactory);
-        for (String dataset : COHORT_MEMBER_ATTRIBUTE_INITIAL_TEST_DATA_XML) {
-            executeDataSet(dataset);
-        }
-    }
-
-    @Test
-    public void shouldGetCohortMemberAttributeByUuid() {
-        CohortMemberAttribute cohortMemberAttribute = dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
-        assertThat(cohortMemberAttribute, notNullValue());
-        assertThat(cohortMemberAttribute.getId(), notNullValue());
-        assertThat(cohortMemberAttribute.getId(), is(COHORT_MEMBER_ATTRIBUTE_ID));
-        assertThat(cohortMemberAttribute.getUuid(), equalTo(COHORT_MEMBER_ATTRIBUTE_UUID));
-    }
-
-    @Test
-    public void shouldGetCohortMemberAttributesByTypeUuid() {
-        List<CohortMemberAttribute> memberAttributes = dao.getCohortMemberAttributesByTypeUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
-
-        assertThat(memberAttributes, notNullValue());
-        assertThat(memberAttributes, hasSize(1));
-    }
-
-    @Test
-    public void shouldCreateNewCohortMemberAttribute() {
-        CohortMemberAttribute cohortAttribute = dao.saveCohortMemberAttribute(TestDataUtils.COHORT_MEMBER_ATTRIBUTE());
-        assertThat(cohortAttribute, notNullValue());
-        assertThat(cohortAttribute.getId(), notNullValue());
-        assertThat(cohortAttribute.getId(), equalTo(TEST_COHORT_MEMBER_ATTRIBUTE_ID));
-        assertThat(cohortAttribute.getValue(), equalTo(COHORT_MEMBER_ATTRIBUTE_VALUE));
-    }
-
-    @Test
-    public void shouldVoidCohortMemberAttribute() {
-        CohortMemberAttribute attribute = dao.deleteCohortMemberAttribute(COHORT_MEMBER_ATTRIBUTE_UUID);
-
-        assertThat(attribute, notNullValue());
-        assertThat(attribute.getVoided(), is(true));
-        assertThat(attribute.getVoidReason(), is("Voided via cohort rest call"));
-    }
-
-    @Test
-    public void shouldPurgeCohortMemberAttribute() {
-        dao.purgeCohortMemberAttribute(dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID));
-
-        assertThat(dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID), nullValue());
-    }
+	
+	//The order is salient
+	private static final String[] COHORT_MEMBER_ATTRIBUTE_INITIAL_TEST_DATA_XML = new String[] {
+	        "org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml",
+	        "org/openmrs/module/cohort/api/hibernate/db/CohortMemberDaoTest_initialTestData.xml",
+	        "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml",
+	        "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeDaoTest_initialTestData.xml" };
+	
+	private static final String COHORT_MEMBER_ATTRIBUTE_UUID = "ddadadd8-8034-4a28-9441-2eb2e7679e10";
+	
+	private static final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
+	
+	private static final int COHORT_MEMBER_ATTRIBUTE_ID = 1;
+	
+	private static final int TEST_COHORT_MEMBER_ATTRIBUTE_ID = 100;
+	
+	private static final String COHORT_MEMBER_ATTRIBUTE_VALUE = "cohortMemberAttribute";
+	
+	private CohortMemberAttributeDaoImpl dao;
+	
+	@Autowired
+	@Qualifier("sessionFactory")
+	private SessionFactory sessionFactory;
+	
+	@Before
+	public void setup() throws Exception {
+		dao = new CohortMemberAttributeDaoImpl();
+		dao.setSessionFactory(sessionFactory);
+		for (String dataset : COHORT_MEMBER_ATTRIBUTE_INITIAL_TEST_DATA_XML) {
+			executeDataSet(dataset);
+		}
+	}
+	
+	@Test
+	public void shouldGetCohortMemberAttributeByUuid() {
+		CohortMemberAttribute cohortMemberAttribute = dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
+		assertThat(cohortMemberAttribute, notNullValue());
+		assertThat(cohortMemberAttribute.getId(), notNullValue());
+		assertThat(cohortMemberAttribute.getId(), is(COHORT_MEMBER_ATTRIBUTE_ID));
+		assertThat(cohortMemberAttribute.getUuid(), equalTo(COHORT_MEMBER_ATTRIBUTE_UUID));
+	}
+	
+	@Test
+	public void shouldGetCohortMemberAttributesByTypeUuid() {
+		List<CohortMemberAttribute> memberAttributes = dao
+		        .getCohortMemberAttributesByTypeUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		
+		assertThat(memberAttributes, notNullValue());
+		assertThat(memberAttributes, hasSize(1));
+	}
+	
+	@Test
+	public void shouldCreateNewCohortMemberAttribute() {
+		CohortMemberAttribute cohortAttribute = dao.saveCohortMemberAttribute(TestDataUtils.COHORT_MEMBER_ATTRIBUTE());
+		assertThat(cohortAttribute, notNullValue());
+		assertThat(cohortAttribute.getId(), notNullValue());
+		assertThat(cohortAttribute.getId(), equalTo(TEST_COHORT_MEMBER_ATTRIBUTE_ID));
+		assertThat(cohortAttribute.getValue(), equalTo(COHORT_MEMBER_ATTRIBUTE_VALUE));
+	}
+	
+	@Test
+	public void shouldVoidCohortMemberAttribute() {
+		CohortMemberAttribute attribute = dao.deleteCohortMemberAttribute(COHORT_MEMBER_ATTRIBUTE_UUID);
+		
+		assertThat(attribute, notNullValue());
+		assertThat(attribute.getVoided(), is(true));
+		assertThat(attribute.getVoidReason(), is("Voided via cohort rest call"));
+	}
+	
+	@Test
+	public void shouldPurgeCohortMemberAttribute() {
+		dao.purgeCohortMemberAttribute(dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID));
+		
+		assertThat(dao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID), nullValue());
+	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeTypeDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/db/impl/CohortMemberAttributeTypeDaoTest.java
@@ -9,6 +9,17 @@
  */
 package org.openmrs.module.cohort.api.db.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,79 +31,70 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-
 @ContextConfiguration(classes = TestSpringConfiguration.class, inheritLocations = false)
 public class CohortMemberAttributeTypeDaoTest extends BaseModuleContextSensitiveTest {
-
-    private static final String COHORT_MEMBER_ATTRIBUTE_TYPE_NAME = "cohort member attributeType Name";
-
-    private static final Integer COHORT_MEMBER_ATTRIBUTE_TYPE_ID = 103;
-
-    private final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
-
-    private CohortMemberAttributeTypeDaoImpl dao;
-
-    @Autowired
-    @Qualifier("sessionFactory")
-    private SessionFactory sessionFactory;
-
-    @Before
-    public void setup() throws Exception{
-        dao = new CohortMemberAttributeTypeDaoImpl();
-        dao.setSessionFactory(sessionFactory);
-        String COHORT_MEMBER_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml";
-        executeDataSet(COHORT_MEMBER_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML);
-    }
-
-    @Test
-    public void shouldGetCohortMemberAttributeTypeByUuid() {
-       CohortMemberAttributeType attributeType = dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
-
-       assertThat(attributeType, notNullValue());
-       assertThat(attributeType.getUuid(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
-    }
-
-    @Test
-    public void shouldGetAllCohortMemberAttributeTypes() {
-        List<CohortMemberAttributeType> attributeTypes = dao.getCohortMemberAttributeTypes();
-
-        assertThat(attributeTypes, notNullValue());
-        assertThat(attributeTypes, hasSize(2));
-        assertThat(attributeTypes, everyItem(hasProperty("name", notNullValue())));
-    }
-
-    @Test
-    public void shouldCreateNewCohortMemberAttributeType() {
-        CohortMemberAttributeType cohortMemberAttributeType = dao.createCohortMemberAttributeType(TestDataUtils.COHORT_MEMBER_ATTRIBUTE_TYPE());
-        assertThat(cohortMemberAttributeType, notNullValue());
-        assertThat(cohortMemberAttributeType.getId(), notNullValue());
-        assertThat(cohortMemberAttributeType.getId(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_ID));
-        assertThat(cohortMemberAttributeType.getName(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_NAME));
-    }
-
-    @Test
-    public void shouldVoidCohortMemberAttributeType() {
-        CohortMemberAttributeType attributeType = dao.deleteCohortMemberAttributeType(TestDataUtils.COHORT_MEMBER_ATTRIBUTE_TYPE(), "Voided via cohort rest call");
-
-        assertThat(attributeType, notNullValue());
-        assertThat(attributeType.getRetired(), is(true));
-        assertThat(attributeType.getRetireReason(), is("Voided via cohort rest call"));
-    }
-
-    @Test
-    public void shouldPurgeCohortMemberAttributeType() {
-        dao.purgeCohortMemberAttribute(dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
-
-        assertThat(dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID), nullValue());
-    }
+	
+	private static final String COHORT_MEMBER_ATTRIBUTE_TYPE_NAME = "cohort member attributeType Name";
+	
+	private static final Integer COHORT_MEMBER_ATTRIBUTE_TYPE_ID = 103;
+	
+	private final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
+	
+	private CohortMemberAttributeTypeDaoImpl dao;
+	
+	@Autowired
+	@Qualifier("sessionFactory")
+	private SessionFactory sessionFactory;
+	
+	@Before
+	public void setup() throws Exception {
+		dao = new CohortMemberAttributeTypeDaoImpl();
+		dao.setSessionFactory(sessionFactory);
+		String COHORT_MEMBER_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml";
+		executeDataSet(COHORT_MEMBER_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML);
+	}
+	
+	@Test
+	public void shouldGetCohortMemberAttributeTypeByUuid() {
+		CohortMemberAttributeType attributeType = dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		
+		assertThat(attributeType, notNullValue());
+		assertThat(attributeType.getUuid(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
+	}
+	
+	@Test
+	public void shouldGetAllCohortMemberAttributeTypes() {
+		List<CohortMemberAttributeType> attributeTypes = dao.getCohortMemberAttributeTypes();
+		
+		assertThat(attributeTypes, notNullValue());
+		assertThat(attributeTypes, hasSize(2));
+		assertThat(attributeTypes, everyItem(hasProperty("name", notNullValue())));
+	}
+	
+	@Test
+	public void shouldCreateNewCohortMemberAttributeType() {
+		CohortMemberAttributeType cohortMemberAttributeType = dao
+		        .createCohortMemberAttributeType(TestDataUtils.COHORT_MEMBER_ATTRIBUTE_TYPE());
+		assertThat(cohortMemberAttributeType, notNullValue());
+		assertThat(cohortMemberAttributeType.getId(), notNullValue());
+		assertThat(cohortMemberAttributeType.getId(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_ID));
+		assertThat(cohortMemberAttributeType.getName(), equalTo(COHORT_MEMBER_ATTRIBUTE_TYPE_NAME));
+	}
+	
+	@Test
+	public void shouldVoidCohortMemberAttributeType() {
+		CohortMemberAttributeType attributeType = dao.deleteCohortMemberAttributeType(
+		    TestDataUtils.COHORT_MEMBER_ATTRIBUTE_TYPE(), "Voided via cohort rest call");
+		
+		assertThat(attributeType, notNullValue());
+		assertThat(attributeType.getRetired(), is(true));
+		assertThat(attributeType.getRetireReason(), is("Voided via cohort rest call"));
+	}
+	
+	@Test
+	public void shouldPurgeCohortMemberAttributeType() {
+		dao.purgeCohortMemberAttribute(dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
+		
+		assertThat(dao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID), nullValue());
+	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImplTest.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.cohort.api.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,84 +25,85 @@ import org.openmrs.module.cohort.CohortMemberAttributeType;
 import org.openmrs.module.cohort.api.db.CohortMemberAttributeDao;
 import org.openmrs.module.cohort.api.db.CohortMemberAttributeTypeDao;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 @RunWith(MockitoJUnitRunner.class)
 public class CohortMemberServiceImplTest {
-
-    private final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "6e0d1303-9a41-40ce-b951-3d8e2aadbf99";
-
-    private final String COHORT_MEMBER_ATTRIBUTE_UUID = "32816782-d578-401c-8475-8ccbb26ce001";
-
-    @Mock
-    private CohortMemberAttributeDao attributeDao;
-
-    @Mock
-    private CohortMemberAttributeTypeDao attributeTypeDao;
-
-    private CohortMemberServiceImpl cohortMemberService;
-
-    @Before
-    public void setup() {
-        cohortMemberService = new CohortMemberServiceImpl();
-        cohortMemberService.setAttributeDao(attributeDao);
-        cohortMemberService.setAttributeTypeDao(attributeTypeDao);
-
-    }
-    @Test
-    public void getCohortMemberAttributeType_shouldReturnMatchingCohortMemberAttributeType() {
-        CohortMemberAttributeType cohortMemberAttributeType = mock(CohortMemberAttributeType.class);
-        when(attributeTypeDao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID)).thenReturn(cohortMemberAttributeType);
-        when(cohortMemberAttributeType.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
-
-        CohortMemberAttributeType result = cohortMemberService.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
-        assertThat(result, notNullValue());
-        assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
-    }
-
-    @Test
-    public void getAllCohortMemberAttributeTypes() {}
-
-    @Test
-    public void saveCohortMemberAttributeType() {
-        CohortMemberAttributeType cohortMemberAttributeType = mock(CohortMemberAttributeType.class);
-        when(attributeTypeDao.createCohortMemberAttributeType(cohortMemberAttributeType)).thenReturn(cohortMemberAttributeType);
-        when(cohortMemberAttributeType.getId()).thenReturn(1);
-
-        CohortMemberAttributeType result = cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
-        assertThat(result, notNullValue());
-        assertThat(result.getId(), is(1));
-    }
-
-    @Test
-    public void purgeCohortMemberAttributeType() {}
-
-    @Test
-    public void getCohortMemberAttributeByUuid() {
-        CohortMemberAttribute cohortMemberAttribute = mock(CohortMemberAttribute.class);
-        when(attributeDao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID)).thenReturn(cohortMemberAttribute);
-        when(cohortMemberAttribute.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_UUID);
-
-        CohortMemberAttribute result = cohortMemberService.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
-        assertThat(result, notNullValue());
-        assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_UUID));
-    }
-
-    @Test
-    public void saveCohortMemberAttribute() {
-        CohortMemberAttribute cohortMemberAttribute = mock(CohortMemberAttribute.class);
-        when(attributeDao.saveCohortMemberAttribute(cohortMemberAttribute)).thenReturn(cohortMemberAttribute);
-        when(cohortMemberAttribute.getId()).thenReturn(1);
-
-        CohortMemberAttribute result = cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
-        assertThat(result, notNullValue());
-        assertThat(result.getId(), is(1));
-    }
-
-    @Test
-    public void purgeCohortMemberAttribute() {}
+	
+	private final String COHORT_MEMBER_ATTRIBUTE_TYPE_UUID = "6e0d1303-9a41-40ce-b951-3d8e2aadbf99";
+	
+	private final String COHORT_MEMBER_ATTRIBUTE_UUID = "32816782-d578-401c-8475-8ccbb26ce001";
+	
+	@Mock
+	private CohortMemberAttributeDao attributeDao;
+	
+	@Mock
+	private CohortMemberAttributeTypeDao attributeTypeDao;
+	
+	private CohortMemberServiceImpl cohortMemberService;
+	
+	@Before
+	public void setup() {
+		cohortMemberService = new CohortMemberServiceImpl();
+		cohortMemberService.setAttributeDao(attributeDao);
+		cohortMemberService.setAttributeTypeDao(attributeTypeDao);
+		
+	}
+	
+	@Test
+	public void getCohortMemberAttributeType_shouldReturnMatchingCohortMemberAttributeType() {
+		CohortMemberAttributeType cohortMemberAttributeType = mock(CohortMemberAttributeType.class);
+		when(attributeTypeDao.getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID))
+		        .thenReturn(cohortMemberAttributeType);
+		when(cohortMemberAttributeType.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		
+		CohortMemberAttributeType result = cohortMemberService
+		        .getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
+	}
+	
+	@Test
+	public void getAllCohortMemberAttributeTypes() {
+	}
+	
+	@Test
+	public void saveCohortMemberAttributeType() {
+		CohortMemberAttributeType cohortMemberAttributeType = mock(CohortMemberAttributeType.class);
+		when(attributeTypeDao.createCohortMemberAttributeType(cohortMemberAttributeType))
+		        .thenReturn(cohortMemberAttributeType);
+		when(cohortMemberAttributeType.getId()).thenReturn(1);
+		
+		CohortMemberAttributeType result = cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
+		assertThat(result, notNullValue());
+		assertThat(result.getId(), is(1));
+	}
+	
+	@Test
+	public void purgeCohortMemberAttributeType() {
+	}
+	
+	@Test
+	public void getCohortMemberAttributeByUuid() {
+		CohortMemberAttribute cohortMemberAttribute = mock(CohortMemberAttribute.class);
+		when(attributeDao.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID)).thenReturn(cohortMemberAttribute);
+		when(cohortMemberAttribute.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_UUID);
+		
+		CohortMemberAttribute result = cohortMemberService.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_UUID));
+	}
+	
+	@Test
+	public void saveCohortMemberAttribute() {
+		CohortMemberAttribute cohortMemberAttribute = mock(CohortMemberAttribute.class);
+		when(attributeDao.saveCohortMemberAttribute(cohortMemberAttribute)).thenReturn(cohortMemberAttribute);
+		when(cohortMemberAttribute.getId()).thenReturn(1);
+		
+		CohortMemberAttribute result = cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
+		assertThat(result, notNullValue());
+		assertThat(result.getId(), is(1));
+	}
+	
+	@Test
+	public void purgeCohortMemberAttribute() {
+	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
@@ -39,50 +39,50 @@ import org.openmrs.module.cohort.api.db.CohortDAO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CohortServiceImplTest {
-
+	
 	private static final int COHORT_TYPE_ID = 123;
-
+	
 	private static final String TEST_COHORT = "test cohort";
-
+	
 	private static final String TEST_ATTRIBUTE_TYPE = "Test attribute type";
-
+	
 	private static final String COHORT_ENCOUNTER_UUID = "e4102924-1a73-4b34-9c74-0278975ffab5";
-
+	
 	private static final String AGE = "Age";
-
+	
 	private static final String TEST_ATT = "test-att";
-
+	
 	private static final String TEST_ATTRIBUTES = "Test attributes";
-
+	
 	private static final int COHORT_VISIT_ID = 100;
-
+	
 	private static final int COHORT_ID = 203;
-
+	
 	private static final int VISIT_TYPE_ID = 340;
-
+	
 	private static final String COHORT_UUID = "5c28c01f-199a-48c7-8693-2a504dd1f4ab";
-
+	
 	private static final String COHORT_ATTRIBUTE_UUID = "06036a52-cf51-4182-9283-dedb15fea65a";
-
+	
 	private static final String COHORT_MEMBER_UUID = "4944bff6-cba2-472e-8b55-3a6c64b9002f";
-
+	
 	private static final String COHORT_TYPE_UUID = "96eebbd7-18c1-4328-9d3d-a5fafd17b186";
-
+	
 	private static final String COHORT_VISIT_UUID = "93ab8fd4-22ce-43dc-8256-f659ed64cbcc";
-
+	
 	@Mock
 	private CohortDAO dao;
-
+	
 	private CohortType cohortType;
-
+	
 	private CohortServiceImpl cohortService;
-
+	
 	@Before
 	public void setup() {
 		cohortService = new CohortServiceImpl();
 		cohortService.setDao(dao);
 	}
-
+	
 	@Before
 	public void initData() {
 		cohortType = new CohortType();
@@ -90,7 +90,7 @@ public class CohortServiceImplTest {
 		cohortType.setCohortTypeId(COHORT_TYPE_ID);
 		cohortType.setName(TEST_COHORT);
 	}
-
+	
 	@Test
 	public void saveCohortMember_shouldSaveCohortMember() {
 		CohortMember member = new CohortMember();
@@ -100,7 +100,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), equalTo(1));
 	}
-
+	
 	@Test
 	public void saveCohort_shouldSaveCohort() {
 		CohortM cohortM = new CohortM();
@@ -111,25 +111,25 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), equalTo(12));
 	}
-
+	
 	@Test
 	public void getCohortTypeById_shouldGetCohortType() {
 		when(dao.getCohortType(COHORT_TYPE_ID)).thenReturn(cohortType);
-
+		
 		CohortType result = cohortService.getCohortTypeById(COHORT_TYPE_ID);
-		assertThat(result , notNullValue());
+		assertThat(result, notNullValue());
 		assertThat(result.getCohortTypeId(), equalTo(COHORT_TYPE_ID));
 		assertThat(result.getName(), equalTo(TEST_COHORT));
 	}
-
+	
 	@Test
 	public void getAllCohortTypes_shouldGetAllCohortTypes() {
 		when(dao.getAllCohortTypes()).thenReturn(Collections.singletonList(cohortType));
 		List<CohortType> resultList = cohortService.getAllCohortTypes();
 		assertThat(resultList, notNullValue());
-		assertThat(resultList, Matchers.<CohortType>hasSize(greaterThanOrEqualTo(1)));
+		assertThat(resultList, Matchers.<CohortType> hasSize(greaterThanOrEqualTo(1)));
 	}
-
+	
 	@Test
 	public void getAllCohortAttributeTypes_shouldGetAllCohortAttributeTypes() {
 		CohortAttributeType attributeType = mock(CohortAttributeType.class);
@@ -140,7 +140,7 @@ public class CohortServiceImplTest {
 		assertThat(resultList.size(), equalTo(1));
 		assertThat(resultList.get(0).getCohortAttributeTypeId(), equalTo(123));
 	}
-
+	
 	@Test
 	public void getCohortAttributeTypeByName_shouldGetCohortAttributeTypeByName() {
 		CohortAttributeType attributeType = mock(CohortAttributeType.class);
@@ -152,7 +152,7 @@ public class CohortServiceImplTest {
 		assertThat(result.getName(), equalTo(TEST_ATTRIBUTE_TYPE));
 		assertThat(result.getCohortAttributeTypeId(), equalTo(123));
 	}
-
+	
 	@Test
 	public void saveCohortEncounter_shouldCreateCohortEncounter() {
 		CohortEncounter cohortEncounter = mock(CohortEncounter.class);
@@ -162,7 +162,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_ENCOUNTER_UUID));
 	}
-
+	
 	@Test
 	public void getAllCohorts_shouldGetAllCohorts() {
 		CohortM cohort = mock(CohortM.class);
@@ -174,7 +174,7 @@ public class CohortServiceImplTest {
 		assertThat(resultList.get(0).getCohortId(), equalTo(12));
 		assertThat(resultList.get(0).getCohortType(), equalTo(cohortType));
 	}
-
+	
 	@Test
 	public void findCohortsMatching_shouldFindMatchingCohort() {
 		CohortM cohort = mock(CohortM.class);
@@ -188,7 +188,7 @@ public class CohortServiceImplTest {
 		assertThat(resultList.get(0).getCohortId(), equalTo(12));
 		assertThat(resultList.get(0).getCohortType(), equalTo(cohortType));
 	}
-
+	
 	@Test
 	public void saveCohortAttribute_shouldCreateCohortAttribute() {
 		CohortAttribute cohortAttribute = mock(CohortAttribute.class);
@@ -198,7 +198,7 @@ public class CohortServiceImplTest {
 		assertThat(attribute, notNullValue());
 		assertThat(attribute.getCohortAttributeId(), equalTo(345));
 	}
-
+	
 	@Test
 	public void saveCohortVisit_shouldCreateCohortVisit() {
 		CohortVisit cohortVisit = mock(CohortVisit.class);
@@ -208,7 +208,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getCohortVisitId(), equalTo(COHORT_VISIT_ID));
 	}
-
+	
 	@Test
 	public void getCohortById_shouldGetCohortById() {
 		CohortM cohortM = mock(CohortM.class);
@@ -218,7 +218,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getCohortId(), equalTo(COHORT_ID));
 	}
-
+	
 	@Test
 	public void getCohortByUuid_shouldGetCohortByUuid() {
 		CohortM cohortM = mock(CohortM.class);
@@ -228,7 +228,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_UUID));
 	}
-
+	
 	@Test
 	public void getCohortVisitByType_shouldReturnCohortVisit() {
 		CohortVisit cohortVisit = mock(CohortVisit.class);
@@ -240,7 +240,7 @@ public class CohortServiceImplTest {
 		assertThat(resultList, notNullValue());
 		assertThat(resultList.get(0).getVisitType().getVisitTypeId(), equalTo(VISIT_TYPE_ID));
 	}
-
+	
 	@Test
 	public void getCohortAttributeByUuid_shouldGetCohortAttributeByUuid() {
 		CohortAttribute cohortAttribute = mock(CohortAttribute.class);
@@ -252,7 +252,7 @@ public class CohortServiceImplTest {
 		assertThat(result.getCohortAttributeId(), equalTo(12));
 		assertThat(result.getUuid(), equalTo(COHORT_ATTRIBUTE_UUID));
 	}
-
+	
 	@Test
 	public void getCohortEncounterByUuid_shouldGetCohortEncounterByUuid() {
 		CohortEncounter cohortEncounter = mock(CohortEncounter.class);
@@ -262,7 +262,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_ENCOUNTER_UUID));
 	}
-
+	
 	@Test
 	public void getCohortMemberByUuid_shouldGetCohortMemberByUuid() {
 		CohortMember cohortMember = mock(CohortMember.class);
@@ -272,7 +272,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_MEMBER_UUID));
 	}
-
+	
 	@Test
 	public void getCohortTypeByUuid_shouldGetCohortTypeByUuid() {
 		CohortType cohortType = mock(CohortType.class);
@@ -282,7 +282,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_TYPE_UUID));
 	}
-
+	
 	@Test
 	public void getCohortVisitByUuid_shouldGetCohortVisitByUuid() {
 		CohortVisit cohortVisit = mock(CohortVisit.class);
@@ -292,7 +292,7 @@ public class CohortServiceImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_VISIT_UUID));
 	}
-
+	
 	@Test
 	public void getCohortsByLocationId_shouldGetCohortsByLocationId() {
 		CohortM cohort = mock(CohortM.class);

--- a/api/src/test/resources/TestApplicationContext.xml
+++ b/api/src/test/resources/TestApplicationContext.xml
@@ -4,6 +4,7 @@
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
 -->

--- a/api/src/test/resources/testHibernate.cfg.xml
+++ b/api/src/test/resources/testHibernate.cfg.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
@@ -8,7 +7,6 @@
 
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
-
 -->
 <!DOCTYPE hibernate-configuration PUBLIC
         "-//Hibernate/Hibernate Configuration DTD 3.0//EN"

--- a/license-format.xml
+++ b/license-format.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<additionalHeaders>
+    <java_style>
+        <firstLine>/*</firstLine>
+        <beforeEachLine> * </beforeEachLine>
+        <endLine> */</endLine>
+        <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </java_style>
+    <myxml_style>
+        <firstLine><![CDATA[<!--]]></firstLine>
+        <beforeEachLine>    </beforeEachLine>
+        <endLine><![CDATA[-->]]></endLine>
+        <skipLine><![CDATA[^<\?xml.*>$]]></skipLine>
+        <firstLineDetectionPattern><![CDATA[(\s|\t)*<!--.*$]]></firstLineDetectionPattern>
+        <lastLineDetectionPattern><![CDATA[.*-->(\s|\t)*$]]></lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </myxml_style>
+</additionalHeaders>

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,7 @@
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can
+obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+graphic logo is a trademark of OpenMRS Inc.

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -162,6 +162,14 @@
 
         <plugins>
             <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>maven-openmrs-plugin</artifactId>
                 <version>1.0.1</version>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -214,4 +214,8 @@
         </plugins>
     </build>
 
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
 </project>

--- a/omod/src/main/java/org/openmrs/module/cohort/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/extension/html/AdminList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under

--- a/omod/src/main/java/org/openmrs/module/cohort/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/extension/html/AdminList.java
@@ -16,34 +16,34 @@ import org.openmrs.module.Extension;
 import org.openmrs.module.web.extension.AdministrationSectionExt;
 
 /**
- * This class defines the links that will appear on the administration page under the
- * "cohort.title" heading.
+ * This class defines the links that will appear on the administration page under the "cohort.title"
+ * heading.
  */
 public class AdminList extends AdministrationSectionExt {
-
-    /**
-     * @see AdministrationSectionExt#getMediaType()
-     */
-    public Extension.MEDIA_TYPE getMediaType() {
-        return Extension.MEDIA_TYPE.html;
-    }
-
-    /**
-     * @see AdministrationSectionExt#getTitle()
-     */
-    public String getTitle() {
-        return "cohort.title";
-    }
-
-    /**
-     * @see AdministrationSectionExt#getLinks()
-     */
-    public Map<String, String> getLinks() {
-        LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
-        map.put("/module/cohort/cohortDashboard.form", "Cohort Dashboard");
-        map.put("/module/cohort/patientSearch.form", "Cohort Patient Search");
-        map.put("/module/cohort/cohortSearch.form", "Cohort Search");
-        return map;
-    }
-
+	
+	/**
+	 * @see AdministrationSectionExt#getMediaType()
+	 */
+	public Extension.MEDIA_TYPE getMediaType() {
+		return Extension.MEDIA_TYPE.html;
+	}
+	
+	/**
+	 * @see AdministrationSectionExt#getTitle()
+	 */
+	public String getTitle() {
+		return "cohort.title";
+	}
+	
+	/**
+	 * @see AdministrationSectionExt#getLinks()
+	 */
+	public Map<String, String> getLinks() {
+		LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+		map.put("/module/cohort/cohortDashboard.form", "Cohort Dashboard");
+		map.put("/module/cohort/patientSearch.form", "Cohort Patient Search");
+		map.put("/module/cohort/cohortSearch.form", "Cohort Search");
+		return map;
+	}
+	
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/rest/v1_0/resource/CohortRest.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/rest/v1_0/resource/CohortRest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under

--- a/omod/src/main/java/org/openmrs/module/cohort/rest/v1_0/resource/CohortRest.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/rest/v1_0/resource/CohortRest.java
@@ -14,18 +14,17 @@ import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceContr
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-
 @Controller
 @RequestMapping("/rest/" + RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE)
 public class CohortRest extends MainResourceController {
-    /**
-     * * @see org.openmrs.module.webservices.rest.web.v1_0.controller.
-     * BaseRestController#getNamespace()
-     */
-    public static final String COHORT_NAMESPACE = "/cohortm";
-
-    @Override
-    public String getNamespace() {
-        return RestConstants.VERSION_1 + COHORT_NAMESPACE;
-    }
+	
+	/**
+	 * * @see org.openmrs.module.webservices.rest.web.v1_0.controller. BaseRestController#getNamespace()
+	 */
+	public static final String COHORT_NAMESPACE = "/cohortm";
+	
+	@Override
+	public String getNamespace() {
+		return RestConstants.VERSION_1 + COHORT_NAMESPACE;
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
@@ -115,17 +115,17 @@ public class CohortAttributesRequestResource extends DataDelegatingCrudResource<
 		}
 		
 		Integer attributeId = null;
-		CohortAttributeType attTypeo = null;
+		CohortAttributeType cohortAttributeType = null;
 		
 		if (org.apache.commons.lang3.StringUtils.isNotBlank(attr)) {
-			attTypeo = Context.getService(CohortService.class).getCohortAttributeTypeByName(attr);
+			cohortAttributeType = Context.getService(CohortService.class).getCohortAttributeTypeByName(attr);
 			
-			if (attTypeo == null) {
-				attTypeo = Context.getService(CohortService.class).getCohortAttributeTypeByUuid(attr);
+			if (cohortAttributeType == null) {
+				cohortAttributeType = Context.getService(CohortService.class).getCohortAttributeTypeByUuid(attr);
 			}
 			
-			if (attTypeo != null) {
-				attributeId = attTypeo.getCohortAttributeTypeId();
+			if (cohortAttributeType != null) {
+				attributeId = cohortAttributeType.getCohortAttributeTypeId();
 			}
 		}
 		

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
@@ -22,14 +22,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortattribute", supportedClass = CohortAttribute.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortattribute", supportedClass = CohortAttribute.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortAttributesRequestResource extends DataDelegatingCrudResource<CohortAttribute> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -49,7 +49,7 @@ public class CohortAttributesRequestResource extends DataDelegatingCrudResource<
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -58,75 +58,75 @@ public class CohortAttributesRequestResource extends DataDelegatingCrudResource<
 		description.addRequiredProperty("cohortAttributeType");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortAttribute save(CohortAttribute cohortAttribute) {
 		return Context.getService(CohortService.class).saveCohortAttribute(cohortAttribute);
 	}
-
+	
 	@Override
 	protected void delete(CohortAttribute cohortAttribute, String reason, RequestContext request) throws ResponseException {
 		cohortAttribute.setVoided(true);
 		cohortAttribute.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortAttribute(cohortAttribute);
 	}
-
+	
 	@Override
 	public void purge(CohortAttribute cohortAttribute, RequestContext request) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortAtt(cohortAttribute);
 	}
-
+	
 	@Override
 	public CohortAttribute newDelegate() {
 		return new CohortAttribute();
 	}
-
+	
 	@Override
 	public CohortAttribute getByUniqueId(String uuid) {
 		return Context.getService(CohortService.class).getCohortAttributeByUuid(uuid);
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String cohort = context.getParameter("cohort");
 		String attr = context.getParameter("attributeType");
-
+		
 		CohortM cohorto = Context.getService(CohortService.class).getCohortByName(cohort);
 		if (cohorto == null) {
 			cohorto = Context.getService(CohortService.class).getCohortByUuid(cohort);
 		}
-
+		
 		if (cohorto == null) {
 			throw new IllegalArgumentException("No valid value specified for param cohort");
 		}
-
+		
 		Integer attributeId = null;
 		CohortAttributeType attTypeo = null;
-
+		
 		if (org.apache.commons.lang3.StringUtils.isNotBlank(attr)) {
 			attTypeo = Context.getService(CohortService.class).getCohortAttributeTypeByName(attr);
-
+			
 			if (attTypeo == null) {
 				attTypeo = Context.getService(CohortService.class).getCohortAttributeTypeByUuid(attr);
 			}
-
+			
 			if (attTypeo != null) {
 				attributeId = attTypeo.getCohortAttributeTypeId();
 			}
 		}
-
+		
 		if (cohorto != null) {
-			List<CohortAttribute> list = Context.getService(CohortService.class)
-					.findCohortAttributes(cohorto.getCohortId(), attributeId);
+			List<CohortAttribute> list = Context.getService(CohortService.class).findCohortAttributes(cohorto.getCohortId(),
+			    attributeId);
 			return new NeedsPaging<CohortAttribute>(list, context);
 		} else {
 			List<CohortAttribute> list = Context.getService(CohortService.class)
-					.getCohortAttributesByAttributeType(attributeId);
+			        .getCohortAttributesByAttributeType(attributeId);
 			return new NeedsPaging<CohortAttribute>(list, context);
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesRequestResource.java
@@ -132,11 +132,11 @@ public class CohortAttributesRequestResource extends DataDelegatingCrudResource<
 		if (cohorto != null) {
 			List<CohortAttribute> list = Context.getService(CohortService.class).findCohortAttributes(cohorto.getCohortId(),
 			    attributeId);
-			return new NeedsPaging<CohortAttribute>(list, context);
+			return new NeedsPaging<>(list, context);
 		} else {
 			List<CohortAttribute> list = Context.getService(CohortService.class)
 			        .getCohortAttributesByAttributeType(attributeId);
-			return new NeedsPaging<CohortAttribute>(list, context);
+			return new NeedsPaging<>(list, context);
 		}
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
@@ -100,6 +100,6 @@ public class CohortAttributesTypeRequestResource extends DataDelegatingCrudResou
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortAttributeType> list = Context.getService(CohortService.class).getAllCohortAttributeTypes();
-		return new NeedsPaging<CohortAttributeType>(list, context);
+		return new NeedsPaging<>(list, context);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
@@ -19,14 +19,14 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortattributetype", supportedClass = CohortAttributeType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortattributetype", supportedClass = CohortAttributeType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortAttributesTypeRequestResource extends DataDelegatingCrudResource<CohortAttributeType> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -46,7 +46,7 @@ public class CohortAttributesTypeRequestResource extends DataDelegatingCrudResou
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -55,30 +55,30 @@ public class CohortAttributesTypeRequestResource extends DataDelegatingCrudResou
 		description.addRequiredProperty("format");
 		return description;
 	}
-
+	
 	@Override
 	public CohortAttributeType save(CohortAttributeType cohortAttributeType) {
 		return Context.getService(CohortService.class).saveCohort(cohortAttributeType);
 	}
-
+	
 	@Override
 	protected void delete(CohortAttributeType cohortAttributeType, String reason, RequestContext context)
-			throws ResponseException {
+	        throws ResponseException {
 		cohortAttributeType.setVoided(true);
 		cohortAttributeType.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohort(cohortAttributeType);
 	}
-
+	
 	@Override
 	public void purge(CohortAttributeType cohortAttributeType, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortAttributes(cohortAttributeType);
 	}
-
+	
 	@Override
 	public CohortAttributeType newDelegate() {
 		return new CohortAttributeType();
 	}
-
+	
 	@Override
 	public CohortAttributeType getByUniqueId(String id) {
 		CohortAttributeType obj = Context.getService(CohortService.class).getCohortAttributeTypeByUuid(id);
@@ -87,7 +87,7 @@ public class CohortAttributesTypeRequestResource extends DataDelegatingCrudResou
 		}
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortAttributeType> list = Context.getService(CohortService.class).getAllCohortAttributeTypes();

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributesTypeRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
@@ -129,6 +129,6 @@ public class CohortEncounterRequestResource extends DataDelegatingCrudResource<C
 		}
 		List<CohortEncounter> list = Context.getService(CohortService.class).getEncountersByCohort(q, cohorto.getCohortId(),
 		    true);
-		return new NeedsPaging<CohortEncounter>(list, context);
+		return new NeedsPaging<>(list, context);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
@@ -21,14 +21,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortencounter", supportedClass = CohortEncounter.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortencounter", supportedClass = CohortEncounter.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortEncounterRequestResource extends DataDelegatingCrudResource<CohortEncounter> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -58,7 +58,7 @@ public class CohortEncounterRequestResource extends DataDelegatingCrudResource<C
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -72,54 +72,54 @@ public class CohortEncounterRequestResource extends DataDelegatingCrudResource<C
 		description.addRequiredProperty("obs");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortEncounter newDelegate() {
 		return new CohortEncounter();
 	}
-
+	
 	@Override
 	public CohortEncounter save(CohortEncounter cohortEncounter) {
 		return Context.getService(CohortService.class).saveCohortEncounter(cohortEncounter);
 	}
-
+	
 	@Override
 	protected void delete(CohortEncounter cohortEncounter, String reason, RequestContext context) throws ResponseException {
 		cohortEncounter.setVoided(true);
 		cohortEncounter.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortEncounter(cohortEncounter);
 	}
-
+	
 	@Override
 	public CohortEncounter getByUniqueId(String uuid) {
 		return Context.getService(CohortService.class).getCohortEncounterByUuid(uuid);
 	}
-
+	
 	@Override
 	public void purge(CohortEncounter cohortEncounter, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortEncounter(cohortEncounter);
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String cohort = context.getParameter("cohort");
 		String q = context.getParameter("q");
-
+		
 		CohortM cohorto = Context.getService(CohortService.class).getCohortByName(cohort);
 		if (cohorto == null) {
 			cohorto = Context.getService(CohortService.class).getCohortByUuid(cohort);
 		}
-
+		
 		if (cohorto == null) {
 			throw new IllegalArgumentException("No valid value specified for param cohort");
 		}
-		List<CohortEncounter> list = Context.getService(CohortService.class)
-				.getEncountersByCohort(q, cohorto.getCohortId(), true);
+		List<CohortEncounter> list = Context.getService(CohortService.class).getEncountersByCohort(q, cohorto.getCohortId(),
+		    true);
 		return new NeedsPaging<CohortEncounter>(list, context);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortEncounterRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortLeaderRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortLeaderRequestResource.java
@@ -21,14 +21,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortleader", supportedClass = CohortLeader.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortleader", supportedClass = CohortLeader.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortLeaderRequestResource extends DataDelegatingCrudResource<CohortLeader> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		if (Context.isAuthenticated()) {
 			DelegatingResourceDescription description = new DelegatingResourceDescription();
-
+			
 			if (rep instanceof FullRepresentation) {
 				description.addProperty("person", Representation.FULL);
 				description.addProperty("cohort");
@@ -44,12 +44,12 @@ public class CohortLeaderRequestResource extends DataDelegatingCrudResource<Coho
 				description.addProperty("uuid");
 				description.addSelfLink();
 			}
-
+			
 			return description;
 		}
 		return null;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -59,12 +59,12 @@ public class CohortLeaderRequestResource extends DataDelegatingCrudResource<Coho
 		description.addProperty("endDate");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortLeader save(CohortLeader cohortLeader) {
 		CohortM cohort = cohortLeader.getCohort();
@@ -75,41 +75,41 @@ public class CohortLeaderRequestResource extends DataDelegatingCrudResource<Coho
 		}
 		return Context.getService(CohortService.class).saveCohortLeader(cohortLeader);
 	}
-
+	
 	@Override
 	protected void delete(CohortLeader cohortLeader, String reason, RequestContext request) throws ResponseException {
 		cohortLeader.setVoided(true);
 		cohortLeader.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortLeader(cohortLeader);
 	}
-
+	
 	@Override
 	public void purge(CohortLeader cohortLeader, RequestContext request) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortLeader(cohortLeader);
 	}
-
+	
 	@Override
 	public CohortLeader newDelegate() {
 		return new CohortLeader();
 	}
-
+	
 	@Override
 	public CohortLeader getByUniqueId(String id) {
 		CohortLeader obj = Context.getService(CohortService.class).getCohortLeaderByUuid(id);
-
+		
 		if (obj == null) {
 			// TODO add to API
 			// obj = Context.getService(CohortService.class).getCohortByName(id);
 		}
-
+		
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String cohortUuid = context.getParameter("cohort");
 		CohortM cohort = Context.getService(CohortService.class).getCohortByUuid(cohortUuid);
-
+		
 		if (cohort == null) {
 			throw new NullPointerException("No Cohort Exists with that UUID");
 		}

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortLeaderRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortLeaderRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.Date;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResource.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.cohort.web.resource;
 
+import java.util.List;
+
 import org.openmrs.api.context.Context;
 import org.openmrs.module.cohort.CohortMember;
 import org.openmrs.module.cohort.CohortMemberAttribute;
@@ -22,63 +24,63 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.BaseAttributeCrudResource1_9;
 
-import java.util.List;
-
 @SuppressWarnings("unused")
-@SubResource( parent = CohortMemberRequestResource.class, path = "attribute",
-        supportedClass = CohortMemberAttribute.class, supportedOpenmrsVersions = {"1.8 - 2.*"})
+@SubResource(parent = CohortMemberRequestResource.class, path = "attribute", supportedClass = CohortMemberAttribute.class, supportedOpenmrsVersions = {
+        "1.8 - 2.*" })
 public class CohortMemberAttributeResource extends BaseAttributeCrudResource1_9<CohortMemberAttribute, CohortMember, CohortMemberRequestResource> {
-
-    private final CohortMemberService cohortMemberService;
-
-    public CohortMemberAttributeResource() {
-        this.cohortMemberService = Context.getRegisteredComponent("cohortMemberService", CohortMemberService.class);
-    }
-
-    @Override
-    public CohortMember getParent(CohortMemberAttribute cohortMemberAttribute) {
-        return cohortMemberAttribute.getCohortMember();
-    }
-
-    @Override
-    public void setParent(CohortMemberAttribute cohortMemberAttribute, CohortMember cohortMember) {
-        cohortMemberAttribute.setCohortMember(cohortMember);
-    }
-
-    @Override
-    public PageableResult doGetAll(CohortMember cohortMember, RequestContext requestContext) throws ResponseException {
-        return new NeedsPaging<>((List<CohortMemberAttribute>) cohortMember.getActiveAttributes(), requestContext);
-    }
-
-    @Override
-    public CohortMemberAttribute getByUniqueId(String uuid) {
-        return cohortMemberService.getCohortMemberAttributeByUuid(uuid);
-    }
-
-    @Override
-    public CohortMemberAttribute save(CohortMemberAttribute cohortMemberAttribute) {
-        return cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
-    }
-
-    @Override
-    protected void delete(CohortMemberAttribute cohortMemberAttribute, String reason, RequestContext requestContext) throws ResponseException {
-        cohortMemberAttribute.setVoided(true);
-        cohortMemberAttribute.setVoidReason(reason);
-        cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
-    }
-
-    @Override
-    public CohortMemberAttribute newDelegate() {
-        return new CohortMemberAttribute();
-    }
-
-    @Override
-    public void purge(CohortMemberAttribute cohortMemberAttribute, RequestContext requestContext) throws ResponseException {
-        cohortMemberService.purgeCohortMemberAttribute(cohortMemberAttribute);
-    }
-
-    @PropertySetter("attributeType")
-    public static void setAttributeType(CohortMemberAttribute cohortMemberAttribute, CohortMemberAttributeType attributeType) {
-        cohortMemberAttribute.setAttributeType(attributeType);
-    }
+	
+	private final CohortMemberService cohortMemberService;
+	
+	public CohortMemberAttributeResource() {
+		this.cohortMemberService = Context.getRegisteredComponent("cohortMemberService", CohortMemberService.class);
+	}
+	
+	@Override
+	public CohortMember getParent(CohortMemberAttribute cohortMemberAttribute) {
+		return cohortMemberAttribute.getCohortMember();
+	}
+	
+	@Override
+	public void setParent(CohortMemberAttribute cohortMemberAttribute, CohortMember cohortMember) {
+		cohortMemberAttribute.setCohortMember(cohortMember);
+	}
+	
+	@Override
+	public PageableResult doGetAll(CohortMember cohortMember, RequestContext requestContext) throws ResponseException {
+		return new NeedsPaging<>((List<CohortMemberAttribute>) cohortMember.getActiveAttributes(), requestContext);
+	}
+	
+	@Override
+	public CohortMemberAttribute getByUniqueId(String uuid) {
+		return cohortMemberService.getCohortMemberAttributeByUuid(uuid);
+	}
+	
+	@Override
+	public CohortMemberAttribute save(CohortMemberAttribute cohortMemberAttribute) {
+		return cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
+	}
+	
+	@Override
+	protected void delete(CohortMemberAttribute cohortMemberAttribute, String reason, RequestContext requestContext)
+	        throws ResponseException {
+		cohortMemberAttribute.setVoided(true);
+		cohortMemberAttribute.setVoidReason(reason);
+		cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
+	}
+	
+	@Override
+	public CohortMemberAttribute newDelegate() {
+		return new CohortMemberAttribute();
+	}
+	
+	@Override
+	public void purge(CohortMemberAttribute cohortMemberAttribute, RequestContext requestContext) throws ResponseException {
+		cohortMemberService.purgeCohortMemberAttribute(cohortMemberAttribute);
+	}
+	
+	@PropertySetter("attributeType")
+	public static void setAttributeType(CohortMemberAttribute cohortMemberAttribute,
+	        CohortMemberAttributeType attributeType) {
+		cohortMemberAttribute.setAttributeType(attributeType);
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResource.java
@@ -22,49 +22,51 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.BaseAttributeTypeCrudResource1_9;
 
 @SuppressWarnings("unused")
-@Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE + "/cohort-member-attribute-type",
-        supportedClass = CohortMemberAttributeType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+@Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
+        + "/cohort-member-attribute-type", supportedClass = CohortMemberAttributeType.class, supportedOpenmrsVersions = {
+                "1.8 - 2.*" })
 public class CohortMemberAttributeTypeResource extends BaseAttributeTypeCrudResource1_9<CohortMemberAttributeType> {
-
-    private final CohortMemberService cohortMemberService;
-
-    public CohortMemberAttributeTypeResource() {
-        this.cohortMemberService = Context.getRegisteredComponent("cohortMemberService", CohortMemberService.class);
-    }
-
-    @Override
-    public CohortMemberAttributeType newDelegate() {
-        return new CohortMemberAttributeType();
-    }
-
-    @Override
-    public CohortMemberAttributeType getByUniqueId(String uuid) {
-        return cohortMemberService.getCohortMemberAttributeTypeByUuid(uuid);
-    }
-
-    @Override
-    protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-        return new NeedsPaging<>(cohortMemberService.getAllCohortMemberAttributeTypes(), context);
-    }
-
-    @Override
-    public CohortMemberAttributeType save(CohortMemberAttributeType cohortMemberAttributeType) {
-        return cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
-    }
-
-    @Override
-    public void delete(String uuid, String reason, RequestContext context) throws ResponseException {
-        cohortMemberService.deleteCohortMemberAttributeType(getByUniqueId(uuid), reason);
-    }
-
-    @Override
-    public void delete(CohortMemberAttributeType cohortMemberAttributeType, String voidReason, RequestContext requestContext)
-            throws ResponseException {
-        cohortMemberService.deleteCohortMemberAttributeType(cohortMemberAttributeType, voidReason);
-    }
-
-    @Override
-    public void purge(CohortMemberAttributeType cohortMemberAttributeType, RequestContext requestContext) throws ResponseException {
-        cohortMemberService.purgeCohortMemberAttributeType(cohortMemberAttributeType);
-    }
+	
+	private final CohortMemberService cohortMemberService;
+	
+	public CohortMemberAttributeTypeResource() {
+		this.cohortMemberService = Context.getRegisteredComponent("cohortMemberService", CohortMemberService.class);
+	}
+	
+	@Override
+	public CohortMemberAttributeType newDelegate() {
+		return new CohortMemberAttributeType();
+	}
+	
+	@Override
+	public CohortMemberAttributeType getByUniqueId(String uuid) {
+		return cohortMemberService.getCohortMemberAttributeTypeByUuid(uuid);
+	}
+	
+	@Override
+	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
+		return new NeedsPaging<>(cohortMemberService.getAllCohortMemberAttributeTypes(), context);
+	}
+	
+	@Override
+	public CohortMemberAttributeType save(CohortMemberAttributeType cohortMemberAttributeType) {
+		return cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
+	}
+	
+	@Override
+	public void delete(String uuid, String reason, RequestContext context) throws ResponseException {
+		cohortMemberService.deleteCohortMemberAttributeType(getByUniqueId(uuid), reason);
+	}
+	
+	@Override
+	public void delete(CohortMemberAttributeType cohortMemberAttributeType, String voidReason, RequestContext requestContext)
+	        throws ResponseException {
+		cohortMemberService.deleteCohortMemberAttributeType(cohortMemberAttributeType, voidReason);
+	}
+	
+	@Override
+	public void purge(CohortMemberAttributeType cohortMemberAttributeType, RequestContext requestContext)
+	        throws ResponseException {
+		cohortMemberService.purgeCohortMemberAttributeType(cohortMemberAttributeType);
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.ArrayList;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberRequestResource.java
@@ -24,20 +24,19 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.DataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
-import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortmember", supportedClass = CohortMember.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortmember", supportedClass = CohortMember.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortMemberRequestResource extends DataDelegatingCrudResource<CohortMember> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -67,7 +66,7 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -81,7 +80,7 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 		description.addProperty("attributes");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -92,12 +91,12 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 		description.addProperty("voided");
 		return description;
 	}
-
+	
 	@Override
 	public CohortMember newDelegate() {
 		return new CohortMember();
 	}
-
+	
 	@Override
 	public CohortMember save(CohortMember cohortMember) throws ResponseException {
 		CohortM cohort = cohortMember.getCohort();
@@ -118,24 +117,24 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 		}
 		return Context.getService(CohortService.class).saveCohortMember(cohortMember);
 	}
-
+	
 	@Override
 	public void delete(CohortMember cohortMember, String reason, RequestContext context) throws ResponseException {
 		cohortMember.setVoided(true);
 		cohortMember.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortMember(cohortMember);
 	}
-
+	
 	@Override
 	public CohortMember getByUniqueId(String uuid) {
 		return Context.getService(CohortService.class).getCohortMemberByUuid(uuid);
 	}
-
+	
 	@Override
 	public void purge(CohortMember cohortMember, RequestContext context) throws ResponseException {
 		throw new UnsupportedOperationException();
 	}
-
+	
 	@PropertySetter("attributes")
 	public static void setAttributes(CohortMember cohortMember, Set<CohortMemberAttribute> attributes) {
 		for (CohortMemberAttribute attribute : attributes) {
@@ -143,7 +142,7 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 		}
 		cohortMember.setAttributes(attributes);
 	}
-
+	
 	@PropertyGetter("display")
 	public String getDisplayString(CohortMember cohortMember) {
 		Patient patient = cohortMember.getPatient();
@@ -151,20 +150,20 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 			PatientIdentifier identifier = patient.getPatientIdentifier();
 			return identifier + "-" + patient.getPersonName().getFullName();
 		}
-
+		
 		return null;
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String cohort = context.getParameter("cohort");
 		String patientUuid = context.getParameter("patient");
 		List<CohortMember> list = new ArrayList<CohortMember>();
-
+		
 		if (StringUtils.isNotBlank(cohort) && StringUtils.isNotBlank(patientUuid)) {
 			throw new IllegalArgumentException(
-					"Patient and Cohort Parameters can't both be declared in the url, search by either cohort or patient, not both");
-
+			        "Patient and Cohort Parameters can't both be declared in the url, search by either cohort or patient, not both");
+			
 		} else if (StringUtils.isNotBlank(cohort)) {
 			CohortM cohorto = Context.getService(CohortService.class).getCohortByName(cohort);
 			if (cohorto == null) {
@@ -175,19 +174,19 @@ public class CohortMemberRequestResource extends DataDelegatingCrudResource<Coho
 				throw new IllegalArgumentException("No match found in cohort");
 			}
 			list = Context.getService(CohortService.class).findCohortMembersByCohort(cohorto.getCohortId());
-
+			
 		} else if (StringUtils.isNotBlank(patientUuid)) {
 			Patient patient = Context.getPatientService().getPatientByUuid(patientUuid);
 			if (patient == null) {
 				throw new IllegalArgumentException("No patient with uuid " + patientUuid);
 			}
 			list = Context.getService(CohortService.class).findCohortMembersByPatient(patient.getId());
-
+			
 		} else {
 			throw new IllegalArgumentException("No valid value specified for param cohort and/or patient");
 		}
-
+		
 		return new NeedsPaging<>(list, context);
-
+		
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberVisitRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberVisitRequestResource.java
@@ -16,14 +16,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortmembervisit", supportedClass = CohortMemberVisit.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortmembervisit", supportedClass = CohortMemberVisit.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortMemberVisitRequestResource extends DataDelegatingCrudResource<CohortMemberVisit> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -40,33 +40,33 @@ public class CohortMemberVisitRequestResource extends DataDelegatingCrudResource
 		}
 		return description;
 	}
-
+	
 	@Override
 	public CohortMemberVisit getByUniqueId(String s) {
 		return Context.getService(CohortService.class).getCohortMemberVisitByUuid(s);
 	}
-
+	
 	@Override
 	protected void delete(CohortMemberVisit cohortMemberVisit, String s, RequestContext requestContext)
-			throws ResponseException {
-
+	        throws ResponseException {
+		
 	}
-
+	
 	@Override
 	public CohortMemberVisit newDelegate() {
 		return new CohortMemberVisit();
 	}
-
+	
 	@Override
 	public CohortMemberVisit save(CohortMemberVisit cohortMemberVisit) {
 		return Context.getService(CohortService.class).saveCohortMemberVisit(cohortMemberVisit);
 	}
-
+	
 	@Override
 	public void purge(CohortMemberVisit cohortMemberVisit, RequestContext requestContext) throws ResponseException {
-
+		
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -74,12 +74,12 @@ public class CohortMemberVisitRequestResource extends DataDelegatingCrudResource
 		description.addProperty("cohortVisit");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	//    @Override
 	//    protected PageableResult doSearch(RequestContext context) {
 	//        String cohort = context.getParameter("cohort_visit");
@@ -96,5 +96,5 @@ public class CohortMemberVisitRequestResource extends DataDelegatingCrudResource
 	//        List<CohortMember> list = Context.getService(CohortService.class).findCohortMembersByCohort(cohorto.getCohortId());
 	//        return new NeedsPaging<CohortMember>(list, context);
 	//    }
-
+	
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberVisitRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberVisitRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import org.openmrs.api.context.Context;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortObsRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortObsRequestResource.java
@@ -21,14 +21,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortobs", supportedClass = CohortObs.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortobs", supportedClass = CohortObs.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortObsRequestResource extends DataDelegatingCrudResource<CohortObs> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -68,7 +68,7 @@ public class CohortObsRequestResource extends DataDelegatingCrudResource<CohortO
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -87,7 +87,7 @@ public class CohortObsRequestResource extends DataDelegatingCrudResource<CohortO
 		description.addProperty("accessionNumber");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -103,45 +103,45 @@ public class CohortObsRequestResource extends DataDelegatingCrudResource<CohortO
 		description.addProperty("accessionNumber");
 		return description;
 	}
-
+	
 	@Override
 	public CohortObs save(CohortObs cohortObs) {
 		return Context.getService(CohortService.class).saveCohortObs(cohortObs);
 	}
-
+	
 	@Override
 	protected void delete(CohortObs cohortObs, String reason, RequestContext context) throws ResponseException {
 		cohortObs.setVoided(true);
 		cohortObs.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortObs(cohortObs);
 	}
-
+	
 	@Override
 	public void purge(CohortObs cohortObs, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortObs(cohortObs);
 	}
-
+	
 	@Override
 	public CohortObs newDelegate() {
 		return new CohortObs();
 	}
-
+	
 	@Override
 	public CohortObs getByUniqueId(String id) {
 		return Context.getService(CohortService.class).getCohortObsByUuid(id);
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String encounter = context.getParameter("encounter");
-
+		
 		CohortEncounter encountero = Context.getService(CohortService.class).getCohortEncounterByUuid(encounter);
 		if (encountero == null) {
 			throw new IllegalArgumentException("No valid value specified for param encounter");
 		}
-
+		
 		List<CohortObs> list = Context.getService(CohortService.class)
-				.getCohortObsByEncounterId(encountero.getEncounterId());
+		        .getCohortObsByEncounterId(encountero.getEncounterId());
 		return new NeedsPaging<CohortObs>(list, context);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortObsRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortObsRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortProgramRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortProgramRequestResource.java
@@ -20,14 +20,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortprogram", supportedClass = CohortProgram.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortprogram", supportedClass = CohortProgram.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortProgramRequestResource extends DataDelegatingCrudResource<CohortProgram> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -45,7 +45,7 @@ public class CohortProgramRequestResource extends DataDelegatingCrudResource<Coh
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -53,34 +53,34 @@ public class CohortProgramRequestResource extends DataDelegatingCrudResource<Coh
 		description.addProperty("description");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortProgram save(CohortProgram cohortProgram) {
 		return Context.getService(CohortService.class).saveCohortProgram(cohortProgram);
 	}
-
+	
 	@Override
 	protected void delete(CohortProgram cohortProgram, String reason, RequestContext context) throws ResponseException {
 		cohortProgram.setVoided(true);
 		cohortProgram.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortProgram(cohortProgram);
 	}
-
+	
 	@Override
 	public void purge(CohortProgram cohortProgram, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortProgram(cohortProgram);
 	}
-
+	
 	@Override
 	public CohortProgram newDelegate() {
 		return new CohortProgram();
 	}
-
+	
 	@Override
 	public CohortProgram getByUniqueId(String uuid) {
 		CohortProgram obj = Context.getService(CohortService.class).getCohortProgramByUuid(uuid);
@@ -89,7 +89,7 @@ public class CohortProgramRequestResource extends DataDelegatingCrudResource<Coh
 		}
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortProgram> list = Context.getService(CohortService.class).getAllCohortPrograms();

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortProgramRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortProgramRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
@@ -1,5 +1,8 @@
 package org.openmrs.module.cohort.web.resource;
 
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
@@ -28,19 +31,16 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
-import java.util.List;
-import java.util.Map;
-
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohort", supportedClass = CohortM.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohort", supportedClass = CohortM.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		if (Context.isAuthenticated()) {
-
+			
 			DelegatingResourceDescription description = null;
-
+			
 			if (rep instanceof DefaultRepresentation) {
 				description = new DelegatingResourceDescription();
 				description.addProperty("name");
@@ -61,9 +61,9 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				description.addSelfLink();
 				return description;
 			} else if (rep instanceof FullRepresentation) {
-
+				
 				description = new DelegatingResourceDescription();
-
+				
 				description.addProperty("name");
 				description.addProperty("description");
 				description.addProperty("location");
@@ -81,21 +81,21 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				description.addProperty("uuid");
 				description.addProperty("auditInfo");
 				description.addProperty("display");
-
+				
 				description.addSelfLink();
-
+				
 				return description;
 			}
-
+			
 			return description;
 		}
 		return null;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
-
+		
 		description.addRequiredProperty("name");
 		description.addProperty("description");
 		description.addRequiredProperty("location");
@@ -109,11 +109,11 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 		description.addProperty("groupCohort");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
-
+		
 		description.addRequiredProperty("name");
 		description.addProperty("description");
 		description.addRequiredProperty("location");
@@ -128,7 +128,7 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 		description.addProperty("voidReason");
 		return description;
 	}
-
+	
 	@Override
 	public CohortM save(CohortM cohort) {
 		if (cohort.getVoided()) {
@@ -146,57 +146,57 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 		}
 		return Context.getService(CohortService.class).saveCohort(cohort);
 	}
-
+	
 	@Override
 	protected void delete(CohortM cohort, String reason, RequestContext request) throws ResponseException {
 		cohort.setVoided(true);
 		cohort.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohort(cohort);
 	}
-
+	
 	@Override
 	public void purge(CohortM cohort, RequestContext request) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohort(cohort);
 	}
-
+	
 	@Override
 	public CohortM newDelegate() {
 		return new CohortM();
 	}
-
+	
 	@Override
 	public CohortM getByUniqueId(String id) {
 		CohortM obj = Context.getService(CohortService.class).getCohortByUuid(id);
-
+		
 		if (obj == null) {
 			// TODO add to API
 			// obj = Context.getService(CohortService.class).getCohortByName(id);
 		}
-
+		
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortM> cohort = Context.getService(CohortService.class).getAllCohorts();
 		return new NeedsPaging<CohortM>(cohort, context);
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		String attributesStr = context.getParameter("attributes");
 		String cohortType = context.getParameter("cohortType");
 		String location = context.getParameter("location");
-
+		
 		Map<String, String> attributes = null;
 		CohortType type = null;
-
+		
 		if (StringUtils.isNotBlank(attributesStr)) {
 			try {
-				attributes = new ObjectMapper()
-						.readValue("{" + attributesStr + "}", new TypeReference<Map<String, String>>() {
-
-						});
+				attributes = new ObjectMapper().readValue("{" + attributesStr + "}",
+				    new TypeReference<Map<String, String>>() {
+				    
+				    });
 			}
 			catch (Exception e) {
 				e.printStackTrace();
@@ -212,7 +212,7 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				throw new RuntimeException("No Cohort Type By Name/Uuid Found Matching The Supplied Parameter");
 			}
 		}
-
+		
 		if (StringUtils.isNotBlank(location)) {
 			Location cohortLocation = Context.getService(LocationService.class).getLocationByUuid(location);
 			if (cohortLocation == null) {
@@ -223,13 +223,13 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 				return new NeedsPaging<CohortM>(cohorts, context);
 			}
 		}
-
-		List<CohortM> cohort = Context.getService(CohortService.class)
-				.findCohortsMatching(context.getParameter("q"), attributes, type);
+		
+		List<CohortM> cohort = Context.getService(CohortService.class).findCohortsMatching(context.getParameter("q"),
+		    attributes, type);
 		return new NeedsPaging<CohortM>(cohort, context);
-
+		
 	}
-
+	
 	/**
 	 * Sets attributes on the given cohort.
 	 *
@@ -240,7 +240,7 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 	public static void setAttributes(CohortM cohort, List<CohortAttribute> attrs) {
 		for (CohortAttribute attr : attrs) {
 			CohortAttribute existingAttribute = cohort.getAttribute(Context.getService(CohortService.class)
-					.getCohortAttributeTypeByUuid(attr.getCohortAttributeType().getUuid()));
+			        .getCohortAttributeTypeByUuid(attr.getCohortAttributeType().getUuid()));
 			if (existingAttribute != null) {
 				if (attr.getValue() == null) {
 					cohort.removeAttribute(existingAttribute);
@@ -252,7 +252,7 @@ public class CohortRequestResource extends DataDelegatingCrudResource<CohortM> {
 			}
 		}
 	}
-
+	
 	@PropertyGetter("display")
 	public static String getDisplay(CohortM cohort) {
 		return cohort.getName();

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRoleRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRoleRequestResource.java
@@ -20,14 +20,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortrole", supportedClass = CohortRole.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortrole", supportedClass = CohortRole.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortRoleRequestResource extends DataDelegatingCrudResource<CohortRole> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -44,7 +44,7 @@ public class CohortRoleRequestResource extends DataDelegatingCrudResource<Cohort
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -52,34 +52,34 @@ public class CohortRoleRequestResource extends DataDelegatingCrudResource<Cohort
 		description.addRequiredProperty("cohortType");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortRole newDelegate() {
 		return new CohortRole();
 	}
-
+	
 	@Override
 	public CohortRole save(CohortRole cohortRole) {
 		return Context.getService(CohortService.class).saveCohortRole(cohortRole);
 	}
-
+	
 	@Override
 	protected void delete(CohortRole cohortRole, String reason, RequestContext context) throws ResponseException {
 		cohortRole.setVoided(true);
 		cohortRole.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortRole(cohortRole);
 	}
-
+	
 	@Override
 	public void purge(CohortRole cohortRole, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortRole(cohortRole);
 	}
-
+	
 	@Override
 	public CohortRole getByUniqueId(String id) {
 		CohortRole obj = Context.getService(CohortService.class).getCohortRoleByUuid(id);
@@ -88,7 +88,7 @@ public class CohortRoleRequestResource extends DataDelegatingCrudResource<Cohort
 		}
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortRole> list = Context.getService(CohortService.class).getAllCohortRoles();

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRoleRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortRoleRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeRequestResource.java
@@ -20,14 +20,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohorttype", supportedClass = CohortType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohorttype", supportedClass = CohortType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortTypeRequestResource extends DataDelegatingCrudResource<CohortType> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -45,7 +45,7 @@ public class CohortTypeRequestResource extends DataDelegatingCrudResource<Cohort
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -53,44 +53,44 @@ public class CohortTypeRequestResource extends DataDelegatingCrudResource<Cohort
 		description.addProperty("description");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortType save(CohortType cohortType) {
 		return Context.getService(CohortService.class).saveCohort(cohortType);
 	}
-
+	
 	@Override
 	protected void delete(CohortType cohortType, String reason, RequestContext request) throws ResponseException {
 		cohortType.setVoided(true);
 		cohortType.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohort(cohortType);
 	}
-
+	
 	@Override
 	public void purge(CohortType cohortType, RequestContext request) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortType(cohortType);
 	}
-
+	
 	@Override
 	public CohortType newDelegate() {
 		return new CohortType();
 	}
-
+	
 	@Override
 	public CohortType getByUniqueId(String uuid) {
 		CohortType obj = Context.getService(CohortService.class).getCohortTypeByUuid(uuid);
 		if (obj == null) {
 			obj = Context.getService(CohortService.class).getCohortTypeByName(uuid);
 		}
-
+		
 		return obj;
 	}
-
+	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CohortType> cohortTypes = Context.getService(CohortService.class).getAllCohortTypes();

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.List;

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortVisitRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortVisitRequestResource.java
@@ -17,14 +17,14 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @Resource(name = RestConstants.VERSION_1 + CohortRest.COHORT_NAMESPACE
-		+ "/cohortvisit", supportedClass = CohortVisit.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
+        + "/cohortvisit", supportedClass = CohortVisit.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
 public class CohortVisitRequestResource extends DataDelegatingCrudResource<CohortVisit> {
-
+	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-
+		
 		DelegatingResourceDescription description = null;
-
+		
 		if (Context.isAuthenticated()) {
 			description = new DelegatingResourceDescription();
 			if (rep instanceof DefaultRepresentation) {
@@ -49,7 +49,7 @@ public class CohortVisitRequestResource extends DataDelegatingCrudResource<Cohor
 		}
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
@@ -60,39 +60,39 @@ public class CohortVisitRequestResource extends DataDelegatingCrudResource<Cohor
 		description.addProperty("endDate");
 		return description;
 	}
-
+	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-
+	
 	@Override
 	public CohortVisit save(CohortVisit cohortVisit) {
 		return Context.getService(CohortService.class).saveCohortVisit(cohortVisit);
 	}
-
+	
 	@Override
 	protected void delete(CohortVisit cohortVisit, String reason, RequestContext context) throws ResponseException {
 		cohortVisit.setVoided(true);
 		cohortVisit.setVoidReason(reason);
 		Context.getService(CohortService.class).saveCohortVisit(cohortVisit);
 	}
-
+	
 	@Override
 	public void purge(CohortVisit cohortVisit, RequestContext context) throws ResponseException {
 		Context.getService(CohortService.class).purgeCohortVisit(cohortVisit);
 	}
-
+	
 	@Override
 	public CohortVisit newDelegate() {
 		return new CohortVisit();
 	}
-
+	
 	@Override
 	public CohortVisit getByUniqueId(String uuid) {
 		return Context.getService(CohortService.class).getCohortVisitByUuid(uuid);
 	}
-
+	
 	@Override
 	protected PageableResult doSearch(RequestContext context) {
 		// TODO Auto-generated method stub

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortVisitRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortVisitRequestResource.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.cohort.web.resource;
 
 import org.openmrs.api.context.Context;

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
 
 <!DOCTYPE module PUBLIC "-//OpenMRS//DTD OpenMRS Config 1.0//EN"
         "https://resources.openmrs.org/doctype/config-1.6.dtd">

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResourceTest.java
@@ -9,4 +9,4 @@
  */
 package org.openmrs.module.cohort.web.resource;
 
-public class CohortMemberAttributeTypeResourceTest{}
+public class CohortMemberAttributeTypeResourceTest {}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     </modules>
 
     <properties>
+        <main.basedir>${project.basedir}</main.basedir>
         <openMRSVersion>2.0.6</openMRSVersion>
         <webservicesRestVersion>2.16</webservicesRestVersion>
         <htmlFormEntryVersion>2.5</htmlFormEntryVersion>
@@ -292,6 +293,46 @@
                             <goals>
                                 <goal>sort</goal>
                             </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>3.0</version>
+                    <configuration>
+                        <header>${main.basedir}${file.separator}license-header.txt</header>
+                        <headerDefinitions>
+                            <headerDefinition>${main.basedir}${file.separator}license-format.xml</headerDefinition>
+                        </headerDefinitions>
+                        <mapping>
+                            <java>JAVA_STYLE</java>
+                            <xml>MYXML_STYLE</xml>
+                        </mapping>
+                        <includes>
+                            <include>**/*.java</include>
+                            <include>**/*.xml</include>
+                            <include>**/*.properties</include>
+                        </includes>
+                        <excludes>
+                            <exclude>license-format.xml</exclude>
+                            <exclude>**/pom.xml</exclude>
+                            <exclude>**/target/**</exclude>
+                            <exclude>.git/**</exclude>
+                            <exclude>.idea/**</exclude>
+                            <exclude>.settings/**</exclude>
+                            <exclude>.externalToolBuilders/</exclude>
+                            <exclude>nbproject/private/</exclude>
+                            <exclude>.vscode/**</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>add-license</id>
+                            <goals>
+                                <goal>format</goal>
+                            </goals>
+                            <phase>validate</phase>
                         </execution>
                     </executions>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <lombokVersion>1.18.16</lombokVersion>
+        <openmrsPlatformToolsVersion>2.4.0</openmrsPlatformToolsVersion>
     </properties>
 
     <dependencyManagement>
@@ -254,6 +255,45 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>2.13.0</version>
+                    <configuration>
+                        <lineEnding>LF</lineEnding>
+                        <configFile>eclipse/OpenMRSFormatter.xml</configFile>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openmrs.tools</groupId>
+                            <artifactId>openmrs-tools</artifactId>
+                            <version>${openmrsPlatformToolsVersion}</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>format</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>1.5.0</version>
+                    <configuration>
+                        <groups>javax, java, *</groups>
+                        <removeUnused>true</removeUnused>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sort</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The code looks prettier now.
- `formatter-maven-plugin` and `impsort-maven-plugin` to help format the code, & sort imports respectively
- `license-maven-plugin` - makes sure every file has a license header (Hopefully that's the right one. #copied from [fhir2 module](https://github.com/openmrs/openmrs-module-fhir2/blob/master/license-header.txt))