### PR TITLE
COH-34: Include/exclude voided cohorts from the response

### DIFF
--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
@@ -66,5 +66,6 @@ public interface CohortService extends OpenmrsService {
 	void purgeAttributeType(@NotNull CohortAttributeType attributeType);
 	
 	//Search
-	List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType);
+	List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	        boolean includeVoided);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/IGenericDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/IGenericDao.java
@@ -36,10 +36,19 @@ public interface IGenericDao<W extends OpenmrsObject & Auditable> {
 	Collection<W> findAll();
 	
 	@Transactional(readOnly = true)
+	Collection<W> findAll(boolean includeRetired);
+	
+	@Transactional(readOnly = true)
 	Collection<W> findBy(PropValue propValue);
 	
 	@Transactional(readOnly = true)
+	Collection<W> findBy(PropValue propValue, boolean includeRetired);
+	
+	@Transactional(readOnly = true)
 	W findByUniqueProp(PropValue propValue);
+	
+	@Transactional(readOnly = true)
+	W findByUniqueProp(PropValue propValue, boolean includeRetired);
 	
 	@Transactional(readOnly = true)
 	Collection<W> findByOr(Criterion... predicates);

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/search/ISearchQuery.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/search/ISearchQuery.java
@@ -21,5 +21,6 @@ import org.openmrs.module.cohort.CohortType;
 public interface ISearchQuery {
 	
 	//Add cohort search methods
-	List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType);
+	List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	        boolean includeVoided);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/search/SearchQueryHandler.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/search/SearchQueryHandler.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.cohort.api.dao.search;
 
+import static org.hibernate.criterion.Restrictions.eq;
+
 import java.util.List;
 import java.util.Map;
 
@@ -25,8 +27,10 @@ import org.springframework.stereotype.Component;
 @Component(value = "cohort.search.cohortSearchHandler")
 public class SearchQueryHandler extends AbstractSearchHandler implements ISearchQuery {
 	
-	public List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType) {
+	public List<CohortM> findCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	        boolean includeVoided) {
 		Criteria criteria = getCurrentSession().createCriteria(CohortM.class);
+		criteria.add(eq("voided", includeVoided));
 		
 		if (StringUtils.isNotBlank(nameMatching)) {
 			criteria.add(Restrictions.ilike("name", nameMatching, MatchMode.ANYWHERE));

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -175,7 +175,8 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType) {
-		return cohortDao.getSearchHandler().findCohorts(nameMatching, attributes, cohortType);
+	public List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	        boolean includeVoided) {
+		return cohortDao.getSearchHandler().findCohorts(nameMatching, attributes, cohortType, includeVoided);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
@@ -29,7 +29,6 @@ public class TestDataUtils {
 	public static CohortAttributeType COHORT_ATTRIBUTE_TYPE() {
 		CohortAttributeType cohortAttributeType = new CohortAttributeType();
 		cohortAttributeType.setUuid("32816782-d578-401c-8475-8ccbb26ce001");
-		cohortAttributeType.setId(1);
 		cohortAttributeType.setName("cohortAttributeType");
 		cohortAttributeType.setDescription("test cohort attribute type");
 		cohortAttributeType.setFormat("java.lang.String");

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeGenericDaoTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -33,11 +34,15 @@ public class CohortAttributeGenericDaoTest extends BaseModuleContextSensitiveTes
 	
 	private static final String COHORT_ATTRIBUTE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml";
 	
-	private static final String COHORT_ATTRIBUTE_UUID = "ddadadd8-8034-4a28-9441-2eb2e7679e10";
+	private static final String VOIDED_COHORT_ATTRIBUTE_UUID = "ddadadd8-8034-4a28-9441-2eb2e7679e10";
 	
-	private static final int COHORT_ATTRIBUTE_ID = 1;
+	private static final String COHORT_ATTRIBUTE_UUID = "99ada908-8034-4a28-9441-2eb2e8979e32";
 	
-	private static final String TEST_COHORT_ATTRIBUTE = "Test cohort attribute";
+	private static final int COHORT_ATTRIBUTE_ID = 2;
+	
+	private static final String VOIDED_COHORT_ATTRIBUTE = "Test cohort attribute";
+	
+	private static final String UN_VOIDED_COHORT_ATTRIBUTE = "System generated patient";
 	
 	private static final int TEST_COHORT_ATTRIBUTE_ID = 200;
 	
@@ -54,11 +59,17 @@ public class CohortAttributeGenericDaoTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void shouldGetCohortAttributeByUuid() {
+	public void getByUuid_shouldReturnCohortAttribute() {
 		CohortAttribute cohortAttribute = dao.get(COHORT_ATTRIBUTE_UUID);
 		assertThat(cohortAttribute, notNullValue());
 		assertThat(cohortAttribute.getCohortAttributeId(), equalTo(COHORT_ATTRIBUTE_ID));
 		assertThat(cohortAttribute.getUuid(), equalTo(COHORT_ATTRIBUTE_UUID));
+	}
+	
+	@Test
+	public void getByUuid_shouldReturnNullForVoidedCohortAttribute() {
+		CohortAttribute cohortAttribute = dao.get(VOIDED_COHORT_ATTRIBUTE_UUID);
+		assertThat(cohortAttribute, nullValue());
 	}
 	
 	@Test
@@ -71,9 +82,19 @@ public class CohortAttributeGenericDaoTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void shouldFindMatchingCohortAttributes() {
+	public void shouldFindMatchingVoidedCohortAttributes() {
 		Collection<CohortAttribute> results = dao.findBy(
-		    PropValue.builder().property("value").value(TEST_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build());
+		    PropValue.builder().property("value").value(VOIDED_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build(),
+		    true);
+		assertThat(results, notNullValue());
+		assertThat(results, not(Matchers.empty()));
+		assertThat(results, Matchers.hasSize(equalTo(1)));
+	}
+	
+	@Test
+	public void shouldFindMatchingUnVoidedCohortAttributes() {
+		Collection<CohortAttribute> results = dao.findBy(PropValue.builder().property("value")
+		        .value(UN_VOIDED_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build());
 		assertThat(results, notNullValue());
 		assertThat(results, not(Matchers.empty()));
 		assertThat(results, Matchers.hasSize(equalTo(1)));

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeTypeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeTypeGenericDaoTest.java
@@ -11,13 +11,14 @@ package org.openmrs.module.cohort.api.dao;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.cohort.CohortAttributeType;
 import org.openmrs.module.cohort.api.SpringTestConfiguration;
-import org.openmrs.module.cohort.api.TestDataUtils;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -28,9 +29,11 @@ public class CohortAttributeTypeGenericDaoTest extends BaseModuleContextSensitiv
 	
 	private static final String COHORT_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml";
 	
-	private static final String COHORT_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
+	private static final String COHORT_ATTRIBUTE_TYPE_UUID = "8eb7fe43-5673-4ebc-80dc-2e5d30251cc3";
 	
-	private static final int COHORT_ATTRIBUTE_TYPE_ID = 1;
+	private static final String VOIDED_COHORT_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
+	
+	private static final int COHORT_ATTRIBUTE_TYPE_ID = 2;
 	
 	@Autowired
 	@Qualifier("cohort.genericDao")
@@ -52,7 +55,7 @@ public class CohortAttributeTypeGenericDaoTest extends BaseModuleContextSensitiv
 	}
 	
 	@Test
-	public void shouldGetCohortAttributeTypeByUuid() {
+	public void getByUuid_shouldReturnCohortAttributeType() {
 		CohortAttributeType cohortAttributeType = dao.get(COHORT_ATTRIBUTE_TYPE_UUID);
 		assertThat(cohortAttributeType, notNullValue());
 		assertThat(cohortAttributeType.getCohortAttributeTypeId(), notNullValue());
@@ -61,20 +64,23 @@ public class CohortAttributeTypeGenericDaoTest extends BaseModuleContextSensitiv
 	}
 	
 	@Test
+	public void getByUuid_shouldReturnNullForVoidedCohortAttributeType() {
+		CohortAttributeType cohortAttributeType = dao.get(VOIDED_COHORT_ATTRIBUTE_TYPE_UUID);
+		assertThat(cohortAttributeType, nullValue());
+	}
+	
+	@Test
 	public void shouldCreateNewCohortAttributeType() {
-		CohortAttributeType cohortAttributeTypeToCreate = dao.createOrUpdate(TestDataUtils.COHORT_ATTRIBUTE_TYPE());
-		assertThat(cohortAttributeTypeToCreate, notNullValue());
-		assertThat(cohortAttributeTypeToCreate.getCohortAttributeTypeId(), notNullValue());
-		assertThat(cohortAttributeTypeToCreate.getCohortAttributeTypeId(),
-		    equalTo(TestDataUtils.COHORT_ATTRIBUTE_TYPE().getCohortAttributeTypeId()));
+		CohortAttributeType cohortAttributeTypeToCreate = new CohortAttributeType();
+		cohortAttributeTypeToCreate.setCohortAttributeTypeId(10);
+		cohortAttributeTypeToCreate.setUuid("fg89jk-34jkl5ks-4583-34jks90");
+		cohortAttributeTypeToCreate.setName("test cohort attribute type");
 		
-		// ISSUE: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1
-		//		CohortAttributeType newlyCreatedCohortAttributeType = dao.get("32816782-d578-401c-8475-8ccbb26ce001");
-		//		assertThat(newlyCreatedCohortAttributeType, notNullValue());
-		//		assertThat(newlyCreatedCohortAttributeType.getCohortAttributeTypeId(), notNullValue());
-		//		assertThat(newlyCreatedCohortAttributeType.getUuid(), equalTo(cohortAttributeTypeToCreate.getUuid()));
-		//		assertThat(newlyCreatedCohortAttributeType.getFormat(), equalTo(cohortAttributeTypeToCreate.getFormat()));
-		//		assertThat(newlyCreatedCohortAttributeType.getCohortAttributeTypeId(), equalTo(cohortAttributeTypeToCreate.getCohortAttributeTypeId()));
+		CohortAttributeType newlyCreatedAttributeType = dao.createOrUpdate(cohortAttributeTypeToCreate);
+		assertThat(newlyCreatedAttributeType, notNullValue());
+		assertThat(newlyCreatedAttributeType.getCohortAttributeTypeId(),
+		    is(cohortAttributeTypeToCreate.getCohortAttributeTypeId()));
+		assertThat(newlyCreatedAttributeType.getName(), is(cohortAttributeTypeToCreate.getName()));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortGenericDaoTest.java
@@ -11,9 +11,12 @@ package org.openmrs.module.cohort.api.dao;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -31,6 +34,8 @@ public class CohortGenericDaoTest extends BaseModuleContextSensitiveTest {
 	private static final String COHORT_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml";
 	
 	private static final String COHORT_UUID = "7f9a2479-c14a-4bfc-bcaa-632860258519";
+	
+	private static final String LOCATION_UUID = "65ab9667-7432-49af-8be8-65a4b58fc78k";
 	
 	private static final String COHORT_NAME = "COVID-19 patients";
 	
@@ -99,5 +104,44 @@ public class CohortGenericDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(createdCohort, notNullValue());
 		assertThat(createdCohort.getCohortId(), equalTo(cohortM.getCohortId()));
 		assertThat(createdCohort.getName(), is(cohortM.getName()));
+	}
+	
+	@Test
+	public void findByLocationUuid_shouldReturnNonVoidedCollectionOfCohortsMatchingTheLocation() {
+		Collection<CohortM> cohorts = dao.findBy(
+		    PropValue.builder().property("uuid").associationPath(Optional.of("location")).value(LOCATION_UUID).build());
+		
+		assertThat(cohorts, notNullValue());
+		assertThat(cohorts, hasSize(1));
+		for (CohortM cohort : cohorts) {
+			assertThat(cohort.getLocation(), notNullValue());
+			assertThat(cohort.getLocation().getUuid(), equalTo(LOCATION_UUID));
+		}
+	}
+	
+	@Test
+	public void findByLocationUuid_shouldReturnCohortsMatchingGivenLocationIncludingVoidedCohorts() {
+		Collection<CohortM> cohorts = dao.findBy(
+		    PropValue.builder().property("uuid").associationPath(Optional.of("location")).value(LOCATION_UUID).build(),
+		    true);
+		
+		assertThat(cohorts, notNullValue());
+		assertThat(cohorts, hasSize(2));
+		
+		for (CohortM cohort : cohorts) {
+			assertThat(cohort.getLocation(), notNullValue());
+			assertThat(cohort.getLocation().getUuid(), equalTo(LOCATION_UUID));
+			assertThat(cohort.getLocation().getName(), is("Cohort-21 Location"));
+		}
+	}
+	
+	@Test
+	public void getByUuid_shouldReturnNullForVoidedOrRetiredCohort() {
+		CohortM cohortToVoid = dao.get(COHORT_UUID);
+		cohortToVoid.setVoided(true);
+		cohortToVoid.setVoidReason("Voided by cohort test");
+		dao.createOrUpdate(cohortToVoid);
+		
+		assertThat(dao.get(COHORT_UUID), nullValue());
 	}
 }

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml
@@ -19,4 +19,6 @@
     <cohort_attribute cohort_attribute_id="1" cohort_attribute_type_id="100" value="Test cohort attribute" creator="1" cohort_id="2"
                       date_created="2005-01-01 00:00:00.0" voided="true" voided_by="1" date_voided="2005-01-01 00:00:00.0"
                       void_reason="This is voided" uuid="ddadadd8-8034-4a28-9441-2eb2e7679e10"/>
+    <cohort_attribute cohort_attribute_id="2" cohort_attribute_type_id="100" value="System generated patient" creator="1" cohort_id="2"
+                      date_created="2021-10-14 00:00:00.0" voided="false" uuid="99ada908-8034-4a28-9441-2eb2e8979e32"/>
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml
@@ -13,4 +13,7 @@
                             description="This is description" creator="1" date_created="2020-01-01 00:00:00.0" voided="true"
                             voided_by="1" date_voided="2020-01-01 00:00:00.0" void_reason="This is voided"
                             uuid="9eb7fe43-2813-4ebc-80dc-2e5d30251bb7"/>
+    <cohort_attributes_type cohort_attribute_type_id="2" name="Patient List Type" format="String"
+                            description="This is description" creator="1" date_created="2021-10-14 00:00:00.0" voided="false"
+                            uuid="8eb7fe43-5673-4ebc-80dc-2e5d30251cc3"/>
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortDaoTest_initialTestData.xml
@@ -9,7 +9,13 @@
     graphic logo is a trademark of OpenMRS Inc.
 -->
 <dataset>
+    <location location_id="101" name="Cohort-21 Location" creator="1" date_created="2021-10-14 00:00:00.0" retired="false"
+              uuid="65ab9667-7432-49af-8be8-65a4b58fc78k"/>
+
     <cohort cohort_id="12" name="COVID-19 patients" description="COVID-19 patients" is_group_cohort="0" creator="1"
             definition_handler="org.openmrs.module.cohort.definition.handler.DefaultCohortDefinitionHandler"
-            date_created="2005-01-01 00:00:00.0" voided="false" uuid="7f9a2479-c14a-4bfc-bcaa-632860258519"/>
+            location_id="101" date_created="2005-01-01 00:00:00.0" voided="false" uuid="7f9a2479-c14a-4bfc-bcaa-632860258519"/>
+    <cohort cohort_id="13" name="Low VL patients" description="Patients with Low viral load count" is_group_cohort="0" creator="1"
+            definition_handler="org.openmrs.module.cohort.definition.handler.DefaultCohortDefinitionHandler"
+            location_id="101" date_created="2021-10-14 00:00:00.0" voided="true" uuid="3f5a7487-c14a-4bfc-bcaa-541860258321"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortResource.java
@@ -202,7 +202,8 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 			return new NeedsPaging<>(new ArrayList<>(cohorts), context);
 		}
 		
-		List<CohortM> cohort = cohortService.findMatchingCohorts(context.getParameter("q"), attributes, type);
+		List<CohortM> cohort = cohortService.findMatchingCohorts(context.getParameter("q"), attributes, type,
+		    context.getIncludeAll());
 		return new NeedsPaging<>(cohort, context);
 		
 	}


### PR DESCRIPTION
## Issue worked on:
https://issues.openmrs.org/projects/COH/issues/COH-34
### Description
- Excludes retired/voided objects by default, unless specified explicitly to include - Using the param `includeAll=true`

**Note**: I haven't enabled this(the ability to retrieve voided/retired objects for all resources). Trivial to add when the need arises.