### PR TITLE
Update cohort attribute/attribute type data model

### DIFF
--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttribute.java
@@ -9,94 +9,40 @@
  */
 package org.openmrs.module.cohort;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.openmrs.attribute.Attribute;
+import org.openmrs.attribute.BaseAttribute;
 
-import java.util.Date;
-
-import org.openmrs.BaseOpenmrsData;
-import org.openmrs.api.context.Context;
-
-@Entity
-@Table(name = "cohort_attribute")
-public class CohortAttribute extends BaseOpenmrsData {
+public class CohortAttribute extends BaseAttribute<CohortAttributeType, CohortM> implements Attribute<CohortAttributeType, CohortM> {
 	
 	private static final long serialVersionUID = 1L;
 	
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Column(name = "cohort_attribute_id")
+	@Getter
+	@Setter
 	private Integer cohortAttributeId;
 	
-	@ManyToOne
-	@JoinColumn(name = "cohort_id")
-	private CohortM cohort;
-	
-	private String value;
-	
-	@ManyToOne
-	@JoinColumn(name = "cohort_attribute_type_id")
-	private CohortAttributeType cohortAttributeType;
-	
-	public Integer getCohortAttributeId() {
-		return cohortAttributeId;
-	}
-	
-	public void setCohortAttributeId(Integer cohortAttributeId) {
-		this.cohortAttributeId = cohortAttributeId;
-	}
-	
-	public CohortM getCohort() {
-		return cohort;
-	}
-	
-	public void setCohort(CohortM cohort) {
-		this.cohort = cohort;
-	}
-	
-	public String getValue() {
-		return value;
-	}
-	
-	public void setValue(String value) {
-		this.value = value;
-	}
-	
-	public CohortAttributeType getCohortAttributeType() {
-		return cohortAttributeType;
-	}
-	
-	public void setCohortAttributeType(CohortAttributeType cohortAttributeType) {
-		this.cohortAttributeType = cohortAttributeType;
+	/**
+	 * @return id - The unique Identifier for the object
+	 */
+	@Override
+	public Integer getId() {
+		return this.cohortAttributeId;
 	}
 	
 	/**
-	 * Convenience method for voiding this attribute
-	 *
-	 * @param reason
-	 * @should set voided bit to true
+	 * @param id - The unique Identifier for the object
 	 */
-	public void voidAttribute(String reason) {
-		setVoided(true);
-		setVoidedBy(Context.getAuthenticatedUser());
-		setVoidReason(reason);
-		setDateVoided(new Date());
-	}
-	
 	@Override
-	public Integer getId() {
-		return getCohortAttributeId();
+	public void setId(Integer id) {
+		this.setCohortAttributeId(id);
 	}
 	
-	@Override
-	public void setId(Integer cohortAttributeId) {
-		setCohortAttributeId(cohortAttributeId);
+	public void setCohort(CohortM cohort) {
+		this.setOwner(cohort);
 	}
 	
+	public CohortM getCohort() {
+		return this.getOwner();
+	}
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortAttributeType.java
@@ -9,77 +9,32 @@
  */
 package org.openmrs.module.cohort;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.openmrs.attribute.AttributeType;
+import org.openmrs.attribute.BaseAttributeType;
 
-import org.openmrs.BaseOpenmrsData;
-
-@Entity
-@Table(name = "cohort_attributes_type")
-public class CohortAttributeType extends BaseOpenmrsData {
+public class CohortAttributeType extends BaseAttributeType<CohortM> implements AttributeType<CohortM> {
 	
 	private static final long serialVersionUID = 1L;
 	
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Column(name = "cohort_attribute_type_id")
+	@Setter
+	@Getter
 	private Integer cohortAttributeTypeId;
 	
-	private String name;
-	
-	private String description;
-	
-	private String format;
-	
-	public Integer getCohortAttributeTypeId() {
-		return cohortAttributeTypeId;
-	}
-	
-	public void setCohortAttributeTypeId(Integer cohortAttributeTypeId) {
-		this.cohortAttributeTypeId = cohortAttributeTypeId;
-	}
-	
-	public String getName() {
-		return name;
-	}
-	
-	public void setName(String name) {
-		this.name = name;
-	}
-	
-	public String getDescription() {
-		return description;
-	}
-	
-	public void setDescription(String description) {
-		this.description = description;
-	}
-	
-	public String getFormat() {
-		return format;
-	}
-	
-	public void setFormat(String format) {
-		this.format = format;
-	}
-	
+	/**
+	 * @return id - The unique Identifier for the object
+	 */
 	@Override
 	public Integer getId() {
-		return getCohortAttributeTypeId();
+		return this.cohortAttributeTypeId;
 	}
 	
+	/**
+	 * @param id - The unique Identifier for the object
+	 */
 	@Override
-	public void setId(Integer cohortAttributeTypeId) {
-		setCohortAttributeTypeId(cohortAttributeTypeId);
+	public void setId(Integer id) {
+		this.setCohortAttributeTypeId(id);
 	}
-	
-	@Override
-	public String toString() {
-		return this.name;
-	}
-	
 }

--- a/api/src/main/java/org/openmrs/module/cohort/CohortM.java
+++ b/api/src/main/java/org/openmrs/module/cohort/CohortM.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.cohort;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,25 +25,28 @@ import javax.persistence.Table;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.openmrs.BaseOpenmrsData;
+import org.hibernate.annotations.BatchSize;
+import org.openmrs.Auditable;
+import org.openmrs.BaseCustomizableData;
 import org.openmrs.Location;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.openmrs.customdatatype.Customizable;
 import org.openmrs.module.cohort.definition.CohortDefinitionHandler;
 import org.openmrs.module.cohort.definition.ManualCohortDefinitionHandler;
 import org.openmrs.module.cohort.exceptions.ManualChangeNotSupportedException;
-import org.openmrs.util.OpenmrsUtil;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 @Entity
 @Table(name = "cohort")
-public class CohortM extends BaseOpenmrsData {
+public class CohortM extends BaseCustomizableData<CohortAttribute> implements Auditable, Customizable<CohortAttribute> {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -67,10 +72,12 @@ public class CohortM extends BaseOpenmrsData {
 	private CohortType cohortType;
 	
 	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
-	private List<CohortAttribute> attributes = new ArrayList<>();
-	
-	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
 	private List<CohortMember> cohortMembers = new ArrayList<>();
+	
+	@Access(AccessType.PROPERTY)
+	@OneToMany(mappedBy = "cohort", cascade = CascadeType.ALL)
+	@BatchSize(size = 100)
+	private Set<CohortAttribute> attributes = new LinkedHashSet<>();
 	
 	@Column(name = "is_group_cohort", nullable = false)
 	private Boolean groupCohort;
@@ -153,254 +160,6 @@ public class CohortM extends BaseOpenmrsData {
 			}
 		}
 		return members;
-	}
-	
-	public List<CohortAttribute> getAttributes() {
-		if (attributes == null) {
-			attributes = new ArrayList<>();
-		}
-		return attributes;
-	}
-	
-	public CohortMember getMember(String uuid) {
-		if (uuid != null) {
-			for (CohortMember member : getCohortMembers()) {
-				if (uuid.equals(member.getUuid()) && !member.getVoided()) {
-					return member;
-				}
-			}
-		}
-		return null;
-	}
-	
-	public void setAttributes(List<CohortAttribute> attributes) {
-		this.attributes = attributes;
-	}
-	
-	/**
-	 * Returns only the non-voided attributes for this cohort
-	 *
-	 * @return list attributes
-	 * @should not get voided attributes
-	 * @should not fail with null attributes
-	 */
-	public List<CohortAttribute> getActiveAttributes() {
-		List<CohortAttribute> attrs = new ArrayList<>();
-		for (CohortAttribute attr : getAttributes()) {
-			if (!attr.getVoided()) {
-				attrs.add(attr);
-			}
-		}
-		return attrs;
-	}
-	
-	/**
-	 * Convenience method to add the <code>attribute</code> to this cohort attribute list if the
-	 * attribute doesn't exist already.<br>
-	 * <br>
-	 * Voids any current attribute with type = <code>newAttribute.getAttributeType()</code><br>
-	 * <br>
-	 * NOTE: This effectively limits cohorts to only one attribute of any given type **
-	 *
-	 * @param newAttribute CohortAttribute to add to the CohortM
-	 * @should fail when new attribute exist
-	 * @should fail when new attribute are the same type with same value
-	 * @should void old attribute when new attribute are the same type with different value
-	 * @should remove attribute when old attribute are temporary
-	 * @should not save an attribute with a null value
-	 * @should not save an attribute with a blank string value
-	 * @should void old attribute when a null or blank string value is added
-	 */
-	public void addAttribute(CohortAttribute newAttribute) {
-		newAttribute.setCohort(this);
-		boolean newIsNull = !StringUtils.hasText(newAttribute.getValue());
-		
-		for (CohortAttribute currentAttribute : getActiveAttributes()) {
-			if (currentAttribute.equals(newAttribute)) {
-				return; // if we have the same CohortAttributeId, don't add the new attribute
-			} else if (currentAttribute.getCohortAttributeType().equals(newAttribute.getCohortAttributeType())) {
-				if (currentAttribute.getValue() != null && currentAttribute.getValue().equals(newAttribute.getValue())) {
-					// this cohort already has this attribute
-					return;
-				}
-				
-				// if the to-be-added attribute isn't already voided itself
-				// and if we have the same type, different value
-				if (!newAttribute.getVoided() || newIsNull) {
-					if (currentAttribute.getCreator() != null) {
-						currentAttribute.voidAttribute("New value: " + newAttribute.getValue());
-					} else {
-						// remove the attribute if it was just temporary (didn't have a creator
-						// attached to it yet)
-						removeAttribute(currentAttribute);
-					}
-				}
-			}
-		}
-		if (!OpenmrsUtil.collectionContains(attributes, newAttribute) && !newIsNull) {
-			attributes.add(newAttribute);
-		}
-	}
-	
-	/**
-	 * Convenience method to get the <code>attribute</code> from this cohort's attribute list if the
-	 * attribute exists already.
-	 *
-	 * @param attribute
-	 * @should not fail when cohort attribute is null
-	 * @should not fail when cohort attribute is not exist
-	 * @should remove attribute when exist
-	 */
-	public void removeAttribute(CohortAttribute attribute) {
-		if (attributes != null) {
-			attributes.remove(attribute);
-		}
-	}
-	
-	/**
-	 * Convenience Method to return the first non-voided cohort attribute matching a cohort attribute
-	 * type. <br>
-	 * <br>
-	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given
-	 * {@link CohortAttributeType}, the given {@link CohortAttributeType} is null, or this cohort has no
-	 * attributes.
-	 *
-	 * @param cohortAttributeType the CohortAttributeType to look for (can be a stub, see
-	 *            {@link CohortAttributeType#equals(Object)} for how its compared)
-	 * @return CohortAttribute that matches the given type
-	 * @should not fail when attribute type is null
-	 * @should not return voided attribute
-	 * @should return null when existing CohortAttributeType is voided
-	 */
-	public CohortAttribute getAttribute(CohortAttributeType cohortAttributeType) {
-		if (cohortAttributeType != null) {
-			for (CohortAttribute attribute : getAttributes()) {
-				if (cohortAttributeType.equals(attribute.getCohortAttributeType()) && !attribute.getVoided()) {
-					return attribute;
-				}
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Convenience method to get this cohort's first attribute that has a CohortAttributeType.name equal
-	 * to <code>attributeName</code>.<br>
-	 * <br>
-	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type name,
-	 * the given name is null, or this cohort has no attributes.
-	 *
-	 * @param attributeName the name string to match on
-	 * @return CohortAttribute whose {@link CohortAttributeType#getName()} matches the given name string
-	 * @should return cohort attribute based on attributeName
-	 * @should return null if AttributeName is voided
-	 */
-	public CohortAttribute getAttribute(String attributeName) {
-		if (attributeName != null) {
-			for (CohortAttribute attribute : getAttributes()) {
-				CohortAttributeType type = attribute.getCohortAttributeType();
-				if (type != null && attributeName.equals(type.getName()) && !attribute.getVoided()) {
-					return attribute;
-				}
-			}
-		}
-		
-		return null;
-	}
-	
-	/**
-	 * Convenience method to get this cohort's first attribute that has a CohortAttributeTypeId equal to
-	 * <code>attributeTypeId</code>.<br>
-	 * <br>
-	 * Returns null if this cohort has no non-voided {@link CohortAttribute} with the given type id or
-	 * this cohort has no attributes.<br>
-	 * <br>
-	 * The given id cannot be null.
-	 *
-	 * @param attributeTypeId the id of the {@link CohortAttributeType} to look for
-	 * @return CohortAttribute whose {@link CohortAttributeType#getId()} equals the given Integer id
-	 * @should return CohortAttribute based on attributeTypeId
-	 * @should return null when existing CohortAttribute with matching attribute type id is voided
-	 */
-	public CohortAttribute getAttribute(Integer attributeTypeId) {
-		for (CohortAttribute attribute : getActiveAttributes()) {
-			if (attributeTypeId.equals(attribute.getCohortAttributeType().getCohortAttributeTypeId())) {
-				return attribute;
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType.name
-	 * equal to <code>attributeName</code>.
-	 *
-	 * @param attributeName
-	 * @should return all CohortAttributes with matching attributeType names
-	 */
-	public List<CohortAttribute> getAttributes(String attributeName) {
-		List<CohortAttribute> cohortAttributes = new ArrayList<>();
-		
-		for (CohortAttribute attribute : getActiveAttributes()) {
-			CohortAttributeType type = attribute.getCohortAttributeType();
-			if (type != null && attributeName.equals(type.getName())) {
-				cohortAttributes.add(attribute);
-			}
-		}
-		
-		return cohortAttributes;
-	}
-	
-	/**
-	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType.id
-	 * equal to <code>attributeTypeId</code>.
-	 *
-	 * @param attributeTypeId
-	 * @should return empty list when matching CohortAttribute by id is voided
-	 * @should return list of cohort attributes based on AttributeTypeId
-	 */
-	public List<CohortAttribute> getAttributes(Integer attributeTypeId) {
-		List<CohortAttribute> ret = new ArrayList<>();
-		
-		for (CohortAttribute attribute : getActiveAttributes()) {
-			if (attributeTypeId.equals(attribute.getCohortAttributeType().getCohortAttributeTypeId())) {
-				ret.add(attribute);
-			}
-		}
-		
-		return ret;
-	}
-	
-	/**
-	 * Convenience method to get all of this cohort's attributes that have a CohortAttributeType equal
-	 * to <code>CohortAttributeType</code>.
-	 *
-	 * @param CohortAttributeType Cohort attribute type
-	 */
-	public List<CohortAttribute> getAttributes(CohortAttributeType CohortAttributeType) {
-		List<CohortAttribute> ret = new ArrayList<>();
-		for (CohortAttribute attribute : getAttributes()) {
-			if (CohortAttributeType.equals(attribute.getCohortAttributeType()) && !attribute.getVoided()) {
-				ret.add(attribute);
-			}
-		}
-		return ret;
-	}
-	
-	/**
-	 * Convenience method for viewing all of the cohort's current attributes
-	 *
-	 * @return Returns a string with all the attributes
-	 */
-	public String printAttributes() {
-		StringBuilder s = new StringBuilder("");
-		
-		for (CohortAttribute attribute : getAttributes()) {
-			s.append(attribute.getCohortAttributeType()).append(" : ").append(attribute.getValue()).append(" : voided? ")
-			        .append(attribute.getVoided()).append("\n");
-		}
-		
-		return s.toString();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/search/SearchQueryHandler.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/search/SearchQueryHandler.java
@@ -40,7 +40,7 @@ public class SearchQueryHandler extends AbstractSearchHandler implements ISearch
 		
 		if (attributes != null && !attributes.isEmpty()) {
 			Criteria attributeCriteria = criteria.createCriteria("attributes").add(Restrictions.eq("voided", false))
-			        .createAlias("cohortAttributeType", "attrType");
+			        .createAlias("attributeType", "attrType");
 			
 			Disjunction disjunction = Restrictions.disjunction();
 			for (String attribute : attributes.keySet()) {

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -163,9 +163,9 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	
 	@Override
 	public CohortAttributeType deleteAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason) {
-		attributeType.setVoided(true);
-		attributeType.setDateVoided(new Date());
-		attributeType.setVoidReason(retiredReason);
+		attributeType.setRetired(true);
+		attributeType.setDateRetired(new Date());
+		attributeType.setRetireReason(retiredReason);
 		return cohortAttributeTypeDao.createOrUpdate(attributeType);
 	}
 	

--- a/api/src/main/resources/CohortAttribute.hbm.xml
+++ b/api/src/main/resources/CohortAttribute.hbm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.cohort">
+    <class name="org.openmrs.module.cohort.CohortAttribute" table="cohort_attribute">
+        <id name="id" type="int" column="cohort_attribute_id">
+            <generator class="native">
+                <param name="sequence">cohort_attribute_id_seq</param>
+            </generator>
+        </id>
+        <many-to-one name="cohort" class="org.openmrs.module.cohort.CohortM" not-null="true" column="cohort_id" />
+        <many-to-one name="attributeType" class="org.openmrs.module.cohort.CohortAttributeType" not-null="true" column="attribute_type_id" />
+        <property name="valueReference" type="text" not-null="true" access="field" column="value_reference" length="65535" />
+        <many-to-one name="creator" class="org.openmrs.User" not-null="true" column="creator" />
+        <property name="dateCreated" type="timestamp" column="date_created" not-null="true" length="19" />
+        <many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
+        <property name="dateChanged" type="timestamp" column="date_changed" length="19" />
+        <property name="voided" type="boolean" column="voided" length="1" not-null="true" />
+        <many-to-one name="voidedBy" class="org.openmrs.User" column="voided_by" />
+        <property name="dateVoided" type="timestamp" column="date_voided" length="19" />
+        <property name="voidReason" type="java.lang.String" column="void_reason" length="255" />
+        <property name="uuid" type="java.lang.String" column="uuid" length="36" unique="true" />
+    </class>
+</hibernate-mapping>

--- a/api/src/main/resources/CohortAttributeType.hbm.xml
+++ b/api/src/main/resources/CohortAttributeType.hbm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.cohort">
+    <class name="CohortAttributeType" table="cohort_attribute_type">
+        <id name="cohortAttributeTypeId" type="int" column="cohort_attribute_type_id">
+            <generator class="native">
+                <param name="sequence">cohort_attribute_type_id_seq</param>
+            </generator>
+        </id>
+        <property name="name" type="string" not-null="true"/>
+        <property name="description" type="string" length="65536"/>
+        <property name="datatypeClassname" type="string" column="datatype" length="255" />
+        <property name="datatypeConfig" type="text" column="datatype_config" length="65535" />
+        <property name="preferredHandlerClassname" type="string" column="preferred_handler" length="255" />
+        <property name="handlerConfig" type="text" column="handler_config" length="65535" />
+        <property name="minOccurs" type="int" column="min_occurs" length="11" not-null="true" />
+        <property name="maxOccurs" type="int" column="max_occurs" length="11" />
+        <many-to-one name="creator" class="org.openmrs.User" not-null="true" column="creator" />
+        <property name="dateCreated" type="timestamp" column="date_created" not-null="true" length="19" />
+        <many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
+        <property name="dateChanged" type="timestamp" column="date_changed" length="19" />
+        <property name="retired" type="boolean" column="retired" length="1" not-null="true" />
+        <many-to-one name="retiredBy" class="org.openmrs.User" column="retired_by" />
+        <property name="dateRetired" type="timestamp" column="date_retired" length="19" />
+        <property name="retireReason" type="java.lang.String" column="retire_reason" length="255" />
+        <property name="uuid" type="java.lang.String" column="uuid" length="36" unique="true" />
+    </class>
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -56,41 +56,47 @@
         </createTable>
     </changeSet>
     <changeSet id="cohortattritype1065" author="sharon">
+        <validCheckSum>3:438b0d7c1f87e1930fc8514e764a006c</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
-                <tableExists tableName="cohort_attributes_type"/>
+                <tableExists tableName="cohort_attribute_type"/>
             </not>
         </preConditions>
-        <createTable tableName="cohort_attributes_type">
+        <createTable tableName="cohort_attribute_type">
             <column name="cohort_attribute_type_id" autoIncrement="true" type="int(11)">
                 <constraints nullable="false" primaryKey="true"/>
             </column>
             <column name="name" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="format" type="varchar(255)">
-                <constraints nullable="false"/>
-            </column>
 
             <column name="description" type="varchar(255)"/>
+            <column name="datatype" type="varchar(255)"/>
+            <column name="datatype_config" type="text"/>
+            <column name="preferred_handler" type="varchar(255)"/>
+            <column name="handler_config" type="text"/>
+            <column name="max_occurs" type="int(11)"/>
+            <column name="min_occurs" type="int(11)">
+                <constraints nullable="false"/>
+            </column>
             <column name="date_created" type="datetime">
                 <constraints nullable="false"/>
             </column>
             <column name="creator" type="int(11)">
-                <constraints nullable="false" foreignKeyName="cohortattributetypecreator_fk" references="users(user_id)"/>
+                <constraints nullable="false" foreignKeyName="cohort_attribute_type_creator_fk" references="users(user_id)"/>
             </column>
             <column name="changed_by" type="int(11)">
-                <constraints foreignKeyName="cohorattributetypeeditor_fk" references="users(user_id)"/>
+                <constraints foreignKeyName="cohort_attribute_type_editor_fk" references="users(user_id)"/>
             </column>
             <column name="date_changed" type="datetime"/>
-            <column name="voided" type="tinyint(1)" defaultValueBoolean="false">
+            <column name="retired" type="tinyint(1)" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
-            <column name="voided_by" type="int(11)">
-                <constraints foreignKeyName="cohortattributetypevoider_fk" references="users(user_id)"/>
+            <column name="retired_by" type="int(11)">
+                <constraints foreignKeyName="cohort_attribute_type_retired_by_fk" references="users(user_id)"/>
             </column>
-            <column name="date_voided" type="datetime"/>
-            <column name="void_reason" type="varchar(255)"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="varchar(255)"/>
             <column name="uuid" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
@@ -151,7 +157,10 @@
             <column name="cohort_type_id" type="int(11)" defaultValue="null"/>
         </addColumn>
     </changeSet>
+
+    <!--Rename value to value_reference -->
     <changeSet id="cohortattribute1065" author="sharon">
+        <validCheckSum>3:17c3a2138b042e7572bbcdb959ba225c</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="cohort_attribute"/>
@@ -162,31 +171,31 @@
                 <constraints nullable="false" primaryKey="true"/>
             </column>
             <column name="cohort_id" type="int(11)">
-                <constraints nullable="false" foreignKeyName="cohortattributecohort_fk" references="cohort(cohort_id)"/>
+                <constraints nullable="false" foreignKeyName="cohort_attribute_cohort_fk" references="cohort(cohort_id)"/>
             </column>
-            <column name="value" type="varchar(255)">
+            <column name="value_reference" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="cohort_attribute_type_id" type="int(11)">
-                <constraints nullable="false" foreignKeyName="cohortattcohortattributetype_fk"
-                             references="cohort_attributes_type(cohort_attribute_type_id)"/>
+            <column name="attribute_type_id" type="int(11)">
+                <constraints nullable="false" foreignKeyName="cohort_attribute_type_fk"
+                             references="cohort_attribute_type(attribute_type_id)"/>
             </column>
 
             <column name="date_created" type="datetime">
                 <constraints nullable="false"/>
             </column>
             <column name="creator" type="int(11)">
-                <constraints nullable="false" foreignKeyName="cohortattributecreator_fk" references="users(user_id)"/>
+                <constraints nullable="false" foreignKeyName="cohort_attribute_creator_fk" references="users(user_id)"/>
             </column>
             <column name="changed_by" type="int(11)">
-                <constraints foreignKeyName="cohortattributeeditor_fk" references="users(user_id)"/>
+                <constraints foreignKeyName="cohort_attribute_editor_fk" references="users(user_id)"/>
             </column>
             <column name="date_changed" type="datetime"/>
             <column name="voided" type="tinyint(1)" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
             <column name="voided_by" type="int(11)">
-                <constraints foreignKeyName="cohortattributevoider_fk" references="users(user_id)"/>
+                <constraints foreignKeyName="cohort_attribute_void_fk" references="users(user_id)"/>
             </column>
             <column name="date_voided" type="datetime"/>
             <column name="void_reason" type="varchar(255)"/>

--- a/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/TestDataUtils.java
@@ -31,7 +31,7 @@ public class TestDataUtils {
 		cohortAttributeType.setUuid("32816782-d578-401c-8475-8ccbb26ce001");
 		cohortAttributeType.setName("cohortAttributeType");
 		cohortAttributeType.setDescription("test cohort attribute type");
-		cohortAttributeType.setFormat("java.lang.String");
+		cohortAttributeType.setDatatypeClassname("java.lang.String");
 		cohortAttributeType.setCohortAttributeTypeId(400);
 		return cohortAttributeType;
 	}
@@ -42,7 +42,7 @@ public class TestDataUtils {
 		cohortAttribute.setUuid("");
 		cohortAttribute.setCohortAttributeId(200);
 		cohortAttribute.setValue("cohortAttribute");
-		cohortAttribute.setCohortAttributeType(COHORT_ATTRIBUTE_TYPE());
+		cohortAttribute.setAttributeType(COHORT_ATTRIBUTE_TYPE());
 		return cohortAttribute;
 	}
 	

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeGenericDaoTest.java
@@ -83,8 +83,8 @@ public class CohortAttributeGenericDaoTest extends BaseModuleContextSensitiveTes
 	
 	@Test
 	public void shouldFindMatchingVoidedCohortAttributes() {
-		Collection<CohortAttribute> results = dao.findBy(
-		    PropValue.builder().property("value").value(VOIDED_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build(),
+		Collection<CohortAttribute> results = dao.findBy(PropValue.builder().property("valueReference")
+		        .value(VOIDED_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build(),
 		    true);
 		assertThat(results, notNullValue());
 		assertThat(results, not(Matchers.empty()));
@@ -93,7 +93,7 @@ public class CohortAttributeGenericDaoTest extends BaseModuleContextSensitiveTes
 	
 	@Test
 	public void shouldFindMatchingUnVoidedCohortAttributes() {
-		Collection<CohortAttribute> results = dao.findBy(PropValue.builder().property("value")
+		Collection<CohortAttribute> results = dao.findBy(PropValue.builder().property("valueReference")
 		        .value(UN_VOIDED_COHORT_ATTRIBUTE).associationPath(Optional.empty()).build());
 		assertThat(results, notNullValue());
 		assertThat(results, not(Matchers.empty()));

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeTypeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortAttributeTypeGenericDaoTest.java
@@ -29,7 +29,7 @@ public class CohortAttributeTypeGenericDaoTest extends BaseModuleContextSensitiv
 	
 	private static final String COHORT_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml";
 	
-	private static final String COHORT_ATTRIBUTE_TYPE_UUID = "8eb7fe43-5673-4ebc-80dc-2e5d30251cc3";
+	private static final String COHORT_ATTRIBUTE_TYPE_UUID = "7fb7fe43-2813-4ebc-78dc-2e5d30251hj6";
 	
 	private static final String VOIDED_COHORT_ATTRIBUTE_TYPE_UUID = "9eb7fe43-2813-4ebc-80dc-2e5d30251bb7";
 	
@@ -87,7 +87,7 @@ public class CohortAttributeTypeGenericDaoTest extends BaseModuleContextSensitiv
 	public void shouldUpdateCohortAttributeType() {
 		CohortAttributeType cohortAttributeTypeToUpdate = dao.get(COHORT_ATTRIBUTE_TYPE_UUID);
 		assertThat(cohortAttributeTypeToUpdate, notNullValue());
-		assertThat(cohortAttributeTypeToUpdate.getDescription(), equalTo("This is description"));
+		assertThat(cohortAttributeTypeToUpdate.getDescription(), equalTo("Test cohort attribute type description"));
 		cohortAttributeTypeToUpdate.setDescription("Updated cohort attribute type");
 		
 		dao.createOrUpdate(cohortAttributeTypeToUpdate);

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeDaoTest_initialTestData.xml
@@ -12,13 +12,12 @@
     <cohort cohort_id="2" name="COVID-19 patients" description="COVID-19 patients" is_group_cohort="0" creator="1"
             definition_handler="org.openmrs.module.cohort.definition.handler.DefaultCohortDefinitionHandler"
             date_created="2005-01-01 00:00:00.0" voided="false" uuid="7f9a2479-c14a-4bfc-bcaa-632860258519"/>
-    <cohort_attributes_type cohort_attribute_type_id="100" name="cohort attribute type" format="String"
-                            description="This is description" creator="1" date_created="2005-01-01 00:00:00.0" voided="true"
-                            voided_by="1" date_voided="2005-01-01 00:00:00.0" void_reason="This is voided"
+    <cohort_attribute_type cohort_attribute_type_id="100" name="cohort attribute type" datatype="java.lang.String" min_occurs="1"
+                            description="This is description" creator="1" date_created="2005-01-01 00:00:00.0" retired="false"
                             uuid="9eb7fe43-2813-4ebc-80dc-2e5d30251bb7"/>
-    <cohort_attribute cohort_attribute_id="1" cohort_attribute_type_id="100" value="Test cohort attribute" creator="1" cohort_id="2"
-                      date_created="2005-01-01 00:00:00.0" voided="true" voided_by="1" date_voided="2005-01-01 00:00:00.0"
-                      void_reason="This is voided" uuid="ddadadd8-8034-4a28-9441-2eb2e7679e10"/>
-    <cohort_attribute cohort_attribute_id="2" cohort_attribute_type_id="100" value="System generated patient" creator="1" cohort_id="2"
+    <cohort_attribute cohort_attribute_id="1" attribute_type_id="100" value_reference="Test cohort attribute" creator="1" cohort_id="2"
+                      date_created="2005-01-01 00:00:00.0" voided="true" voided_by="1" date_voided="2021-05-01 00:00:00.0"
+                      void_reason="retired by test" uuid="ddadadd8-8034-4a28-9441-2eb2e7679e10"/>
+    <cohort_attribute cohort_attribute_id="2" attribute_type_id="100" value_reference="System generated patient" creator="1" cohort_id="2"
                       date_created="2021-10-14 00:00:00.0" voided="false" uuid="99ada908-8034-4a28-9441-2eb2e8979e32"/>
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/cohort/api/hibernate/db/CohortAttributeTypeDaoTest_initialTestData.xml
@@ -9,11 +9,11 @@
     graphic logo is a trademark of OpenMRS Inc.
 -->
 <dataset>
-    <cohort_attributes_type cohort_attribute_type_id="1" name="cohort attribute type" format="String"
-                            description="This is description" creator="1" date_created="2020-01-01 00:00:00.0" voided="true"
-                            voided_by="1" date_voided="2020-01-01 00:00:00.0" void_reason="This is voided"
-                            uuid="9eb7fe43-2813-4ebc-80dc-2e5d30251bb7"/>
-    <cohort_attributes_type cohort_attribute_type_id="2" name="Patient List Type" format="String"
-                            description="This is description" creator="1" date_created="2021-10-14 00:00:00.0" voided="false"
-                            uuid="8eb7fe43-5673-4ebc-80dc-2e5d30251cc3"/>
+    <cohort_attribute_type cohort_attribute_type_id="1" name="Test cohort attribute" datatype="String"
+                            description="This is voided cohort attribute type description" creator="1" date_created="2021-01-01 00:00:00.0" retired="true"
+                            retired_by="1" date_retired="2020-10-01 00:00:00.0" retire_reason="This is retired"
+                            min_occurs="1" uuid="9eb7fe43-2813-4ebc-80dc-2e5d30251bb7"/>
+    <cohort_attribute_type cohort_attribute_type_id="2" name="System generated patient" datatype="java.lang.String"
+                            description="Test cohort attribute type description" creator="1" date_created="2021-10-17 00:00:00.0" retired="0"
+                            min_occurs="1" uuid="7fb7fe43-2813-4ebc-78dc-2e5d30251hj6"/>
 </dataset>

--- a/api/src/test/resources/testHibernate.cfg.xml
+++ b/api/src/test/resources/testHibernate.cfg.xml
@@ -115,6 +115,8 @@
 
         <mapping resource="CohortMemberAttribute.hbm.xml" />
         <mapping resource="CohortMemberAttributeType.hbm.xml" />
+        <mapping resource="CohortAttribute.hbm.xml" />
+        <mapping resource="CohortAttributeType.hbm.xml" />
 
     </session-factory>
 

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResource.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.cohort.web.resource;
 
 import java.util.ArrayList;
-import java.util.Collection;
 
 import org.openmrs.api.context.Context;
 import org.openmrs.module.cohort.CohortAttributeType;
@@ -18,19 +17,15 @@ import org.openmrs.module.cohort.api.CohortService;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
-import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
-import org.openmrs.module.webservices.rest.web.resource.impl.DataDelegatingCrudResource;
-import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.BaseAttributeTypeCrudResource1_9;
 
 @SuppressWarnings("unused")
 @Resource(name = RestConstants.VERSION_1 + CohortMainRestController.COHORT_NAMESPACE
         + "/cohortattributetype", supportedClass = CohortAttributeType.class, supportedOpenmrsVersions = { "1.8 - 2.*" })
-public class CohortAttributeTypeResource extends DataDelegatingCrudResource<CohortAttributeType> {
+public class CohortAttributeTypeResource extends BaseAttributeTypeCrudResource1_9<CohortAttributeType> {
 	
 	private final CohortService cohortService;
 	
@@ -39,49 +34,8 @@ public class CohortAttributeTypeResource extends DataDelegatingCrudResource<Coho
 	}
 	
 	@Override
-	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		if (Context.isAuthenticated()) {
-			if (rep instanceof DefaultRepresentation) {
-				final DelegatingResourceDescription description = new DelegatingResourceDescription();
-				description.addProperty("name");
-				description.addProperty("description");
-				description.addProperty("format");
-				description.addProperty("uuid");
-				description.addSelfLink();
-				description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
-				return description;
-			} else if (rep instanceof FullRepresentation) {
-				final DelegatingResourceDescription description = new DelegatingResourceDescription();
-				description.addProperty("name");
-				description.addProperty("description");
-				description.addProperty("format");
-				description.addProperty("uuid");
-				description.addProperty("auditInfo");
-				description.addSelfLink();
-				return description;
-			}
-		}
-		return null;
-	}
-	
-	@Override
-	public DelegatingResourceDescription getCreatableProperties() {
-		DelegatingResourceDescription description = new DelegatingResourceDescription();
-		description.addRequiredProperty("name");
-		description.addProperty("description");
-		description.addRequiredProperty("format");
-		return description;
-	}
-	
-	@Override
 	public CohortAttributeType save(CohortAttributeType cohortAttributeType) {
 		return cohortService.createAttributeType(cohortAttributeType);
-	}
-	
-	@Override
-	protected void delete(CohortAttributeType cohortAttributeType, String reason, RequestContext context)
-	        throws ResponseException {
-		cohortService.deleteAttributeType(cohortAttributeType, reason);
 	}
 	
 	@Override
@@ -101,7 +55,6 @@ public class CohortAttributeTypeResource extends DataDelegatingCrudResource<Coho
 	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-		Collection<CohortAttributeType> allCohortAttributeTypes = cohortService.findAllAttributeTypes();
-		return new NeedsPaging<>(new ArrayList<>(allCohortAttributeTypes), context);
+		return new NeedsPaging<>(new ArrayList<>(cohortService.findAllAttributeTypes()), context);
 	}
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -52,6 +52,8 @@
     <mappingFiles>
         CohortMemberAttribute.hbm.xml
         CohortMemberAttributeType.hbm.xml
+        CohortAttribute.hbm.xml
+        CohortAttributeType.hbm.xml
     </mappingFiles>
 
     <!-- Internationalization -->


### PR DESCRIPTION
This PR updates the cohort attribute & attribute type data model.  Additionally, this comes with quite substantial changes to the database(this is a concern for those already using the cohort module. For new users no worries). Opted for making changes directly to DB, rather than liquibase changesets. Below are the DB changes (need to make for users already using the cohort module).
```SQL
-- Rename value to value_reference
ALTER TABLE `openmrs`.cohort_attribute CHANGE value value_reference text;

-- Rename cohort_attribute_type_id to attribute_type_id
ALTER TABLE `openmrs`.cohort_attribute CHANGE cohort_attribute_type_id attribute_type_id int(11);

-- Rename cohort_attributes_type table to cohort_attribute_type
ALTER TABLE  `openmrs`.cohort_attributes_type RENAME TO  `openmrs`.cohort_attribute_type;

-- Add min_occurs
ALTER TABLE `openmrs`.cohort_attribute_type
ADD COLUMN min_occurs int(11) not null

-- Add max_occurs
ALTER TABLE `openmrs`.cohort_attribute_type
ADD COLUMN max_occurs int(11)

-- Add preferred_handler
ALTER TABLE `openmrs`.cohort_attribute_type
ADD COLUMN preferred_handler VARCHAR(255);

-- Add datatype_config
ALTER TABLE `openmrs`.cohort_attribute_type ADD COLUMN datatype_config text;

-- Add handler_config
ALTER TABLE `openmrs`.cohort_attribute_type ADD COLUMN handler_config text;

-- Rename format to datatype
ALTER TABLE `openmrs`.cohort_attribute_type CHANGE format datatype VARCHAR(255);

-- voided -> retired
ALTER TABLE `openmrs`.cohort_attribute_type CHANGE voided retired tinyint(1) not null

-- voided_by -> retired_by
ALTER TABLE `openmrs`.cohort_attribute_type CHANGE voided_by retired_by int(11)

-- void_reason -> retire_reason
ALTER TABLE `openmrs`.cohort_attribute_type CHANGE void_reason retire_reason varchar(255);

-- date_voided -> date_retired
ALTER TABLE `openmrs`.cohort_attribute_type CHANGE date_voided date_retired datetime;
```