### PR TITLE
(fix) Don't validate name uniqueness when updating an existing cohort

### DIFF
--- a/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
@@ -43,10 +43,12 @@ public class CohortMValidator implements Validator {
 		
 		CohortM cohort = (CohortM) command;
 		
-		// Cohort should have a unique name
-		CohortM cohortByName = Context.getService(CohortService.class).getCohort(cohort.getName());
-		if (cohortByName != null) {
-			errors.rejectValue("name", "A cohort with this name already exists");
+		// Cohort should have a unique name in case it's a new one
+		if (cohort.getId() == null) {
+			CohortM cohortByName = Context.getService(CohortService.class).getCohort(cohort.getName());
+			if (cohortByName != null) {
+				errors.rejectValue("name", "A cohort with this name already exists");
+			}
 		}
 		
 		// EndDate should less than startDate

--- a/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
@@ -43,12 +43,10 @@ public class CohortMValidator implements Validator {
 		
 		CohortM cohort = (CohortM) command;
 		
-		// Cohort should have a unique name in case it's a new one
-		if (cohort.getId() == null) {
-			CohortM cohortByName = Context.getService(CohortService.class).getCohort(cohort.getName());
-			if (cohortByName != null) {
-				errors.rejectValue("name", "A cohort with this name already exists");
-			}
+		// Cohort should have a unique name
+		CohortM cohortByName = Context.getService(CohortService.class).getCohort(cohort.getName());
+		if (cohortByName != null && cohortByName.getId() != cohort.getId()) {
+			errors.rejectValue("name", "A cohort with this name already exists");
 		}
 		
 		// EndDate should less than startDate

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
@@ -46,22 +46,6 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 		assertThat(result, notNullValue());
 		assertThat(result.getName(), equalTo("Updated Test Cohort"));
 	}
-
-	@Test
-	public void saveCohort_shouldUpdateCohortWhileKeepingName() {
-		CohortM cohortM = new CohortM();
-		cohortM.setName("Test Cohort");
-		cohortM.setCohortType(new CohortType());
-
-		CohortM savedCohort = Context.getService(CohortService.class).saveCohort(cohortM);
-		savedCohort.setDescription("Updated Test Description");
-
-		CohortM result = Context.getService(CohortService.class).saveCohort(savedCohort);
-
-		assertThat(result, notNullValue());
-		assertThat(result.getName(), equalTo("Test Cohort"));
-		assertThat(result.getDescription(), equalTo("Updated Test Description"));
-	}
 	
 	@Test
 	public void saveCohort_shouldSaveCohortMembers() {

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
@@ -46,6 +46,22 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 		assertThat(result, notNullValue());
 		assertThat(result.getName(), equalTo("Updated Test Cohort"));
 	}
+
+	@Test
+	public void saveCohort_shouldUpdateCohortWhileKeepingName() {
+		CohortM cohortM = new CohortM();
+		cohortM.setName("Test Cohort");
+		cohortM.setCohortType(new CohortType());
+
+		CohortM savedCohort = Context.getService(CohortService.class).saveCohort(cohortM);
+		savedCohort.setDescription("Updated Test Description");
+
+		CohortM result = Context.getService(CohortService.class).saveCohort(savedCohort);
+
+		assertThat(result, notNullValue());
+		assertThat(result.getName(), equalTo("Test Cohort"));
+		assertThat(result.getDescription(), equalTo("Updated Test Description"));
+	}
 	
 	@Test
 	public void saveCohort_shouldSaveCohortMembers() {

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
@@ -1,0 +1,50 @@
+package org.openmrs.module.cohort.api.impl;
+
+import org.junit.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.cohort.CohortM;
+import org.openmrs.module.cohort.CohortType;
+import org.openmrs.module.cohort.api.CohortService;
+import org.openmrs.module.cohort.validators.CohortMValidator;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CohortValidatorTest extends BaseModuleContextSensitiveTest {
+
+	@Autowired
+	CohortMValidator validator;
+
+	@Test
+	public void saveCohort_shouldFailValidationOnExixtingName() {
+		CohortM cohort = new CohortM();
+		cohort.setCohortType(new CohortType());
+		cohort.setName("Test Cohort");
+		Context.getService(CohortService.class).saveCohort(cohort);
+
+		CohortM invalidCohort = new CohortM();
+		invalidCohort.setCohortType(new CohortType());
+		invalidCohort.setName("Test Cohort");
+		Errors errors = new BeanPropertyBindingResult(invalidCohort, "invalidCohort");
+		validator.validate(invalidCohort, errors);
+
+		assertThat(errors.getErrorCount(), equalTo(1));
+	}
+
+	@Test
+	public void saveCohort_shouldPassValidationOnUpdatingWhileKeepingName() {
+		CohortM cohort = new CohortM();
+		cohort.setName("Test Cohort");
+		cohort.setCohortType(new CohortType());
+		Context.getService(CohortService.class).saveCohort(cohort);
+		cohort.setDescription("Updated Cohort description");
+		Errors errors = new BeanPropertyBindingResult(cohort, "invalid cohort");
+		validator.validate(cohort, errors);
+
+		assertThat(errors.getErrorCount(), equalTo(0));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
@@ -20,7 +20,7 @@ public class CohortValidatorTest extends BaseModuleContextSensitiveTest {
 	CohortMValidator validator;
 
 	@Test
-	public void saveCohort_shouldFailValidationOnExixtingName() {
+	public void saveCohort_shouldFailValidationOnExistingName() {
 		CohortM cohort = new CohortM();
 		cohort.setCohortType(new CohortType());
 		cohort.setName("Test Cohort");

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
@@ -49,6 +49,28 @@ public class CohortResourceControllerTest extends MainResourceControllerTest {
 		assertEquals(1, members.size());
 		assertEquals("da7f524f-27ce-4bb2-86d6-6d1d05312bd5", members.iterator().next().getPatient().getUuid());
 	}
+
+	@Test
+	public void shouldUpdateCohortWhileKeepingName() throws Exception {
+
+		CohortM cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		assertNull(cohort);
+
+		String createJson = "{ \"name\":\"cohort name\", \"description\":\"cohort description\"," + "\"cohortMembers\": [ {"
+				+ "\"patient\":\"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\"" + " } ]" + "}";
+
+		handle(newPostRequest(getURI(), createJson));
+		cohort = Context.getService(CohortService.class).getCohort("cohort name");
+
+		String updateJson = "{ \"name\":\"cohort name\", \"description\":\"updated cohort description\"," + "\"cohortMembers\": [ {"
+				+ "\"patient\":\"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\"" + " } ]" + "}";
+
+		handle(newPostRequest(getURI() + "/" + cohort.getUuid(), updateJson));
+		cohort = Context.getService(CohortService.class).getCohort("cohort name");
+
+		assertNotNull(cohort);
+		assertEquals("updated cohort description", cohort.getDescription());
+	}
 	
 	@Override
 	public void shouldGetDefaultByUuid() throws Exception {

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
@@ -62,8 +62,7 @@ public class CohortResourceControllerTest extends MainResourceControllerTest {
 		handle(newPostRequest(getURI(), createJson));
 		cohort = Context.getService(CohortService.class).getCohort("cohort name");
 
-		String updateJson = "{ \"name\":\"cohort name\", \"description\":\"updated cohort description\"," + "\"cohortMembers\": [ {"
-				+ "\"patient\":\"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\"" + " } ]" + "}";
+		String updateJson = "{ \"name\":\"cohort name\", \"description\":\"updated cohort description\" } ]" + "}";
 
 		handle(newPostRequest(getURI() + "/" + cohort.getUuid(), updateJson));
 		cohort = Context.getService(CohortService.class).getCohort("cohort name");


### PR DESCRIPTION
Prior to this change, when updating an existing cohort, if it's name was not changed, an error was returned saying that there was already a cohort with that name. With this change, when updating a cohort, it's id is verified when validating name uniqueness.