### PR TITLE
COH-53: Cohort module should use standard naming conventions for AOP

### DIFF
--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
@@ -20,37 +20,37 @@ import org.openmrs.module.cohort.CohortMemberAttributeType;
 
 public interface CohortMemberService extends OpenmrsService {
 	
-	CohortMember getByUuid(@NotNull String uuid);
+	CohortMember getCohortMemberByUuid(@NotNull String uuid);
 	
-	CohortMember getByName(@NotNull String name);
+	CohortMember getCohortMemberByName(@NotNull String name);
 	
-	Collection<CohortMember> findAll();
+	Collection<CohortMember> findAllCohortMembers();
 	
-	CohortMember createOrUpdate(@NotNull CohortMember cohortMember);
+	CohortMember saveCohortMember(@NotNull CohortMember cohortMember);
 	
-	CohortMember voidCohortMember(@NotNull CohortMember cohortMember, String voidReason);
+	void voidCohortMember(@NotNull CohortMember cohortMember, String voidReason);
 	
-	void purge(@NotNull CohortMember cohortMember);
+	void purgeCohortMember(@NotNull CohortMember cohortMember);
 	
-	CohortMemberAttributeType getAttributeTypeByUuid(@NotNull String uuid);
+	CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
 	
-	Collection<CohortMemberAttributeType> findAllAttributeTypes();
+	Collection<CohortMemberAttributeType> findAllCohortMemberAttributeTypes();
 	
-	CohortMemberAttributeType createAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
+	CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttributeType);
 	
-	CohortMemberAttributeType voidAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason);
+	void voidCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute, String voidReason);
 	
-	void purgeAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
+	void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
 	
-	CohortMemberAttribute getAttributeByUuid(@NotNull String uuid);
+	CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
 	
-	Collection<CohortMemberAttribute> getAttributeByTypeUuid(@NotNull String attributeTypeUuid);
+	Collection<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(@NotNull String attributeTypeUuid);
 	
-	CohortMemberAttribute createAttribute(CohortMemberAttribute cohortMemberAttribute);
+	CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
 	
-	CohortMemberAttribute deleteAttribute(CohortMemberAttribute attribute, String voidReason);
+	void voidCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason);
 	
-	void purgeAttribute(CohortMemberAttribute cohortMemberAttribute);
+	void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
 	
 	//Search methods
 	Collection<CohortMember> findCohortMembersByCohortUuid(@NotNull String cohortUuid);
@@ -59,5 +59,6 @@ public interface CohortMemberService extends OpenmrsService {
 	
 	Collection<CohortMember> findCohortMembersByPatientName(@NotNull String patientName);
 	
-	Collection<CohortMember> findCohortMembersByCohortAndPatient(@NotNull String cohortUuid, @NotNull String patientName);
+	Collection<CohortMember> findCohortMembersByCohortAndPatientName(@NotNull String cohortUuid,
+	        @NotNull String patientName);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortMemberService.java
@@ -17,48 +17,70 @@ import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.cohort.CohortMember;
 import org.openmrs.module.cohort.CohortMemberAttribute;
 import org.openmrs.module.cohort.CohortMemberAttributeType;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CohortMemberService extends OpenmrsService {
 	
+	@Transactional(readOnly = true)
 	CohortMember getCohortMemberByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	CohortMember getCohortMemberByName(@NotNull String name);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMember> findAllCohortMembers();
 	
+	@Transactional
 	CohortMember saveCohortMember(@NotNull CohortMember cohortMember);
 	
+	@Transactional
 	void voidCohortMember(@NotNull CohortMember cohortMember, String voidReason);
 	
+	@Transactional
 	void purgeCohortMember(@NotNull CohortMember cohortMember);
 	
+	@Transactional(readOnly = true)
 	CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMemberAttributeType> findAllCohortMemberAttributeTypes();
 	
+	@Transactional
 	CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttributeType);
 	
+	@Transactional
 	void voidCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute, String voidReason);
 	
+	@Transactional
 	void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute);
 	
+	@Transactional(readOnly = true)
 	CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(@NotNull String attributeTypeUuid);
 	
+	@Transactional
 	CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
 	
+	@Transactional
 	void voidCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason);
 	
+	@Transactional
 	void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType);
 	
 	//Search methods
+	
+	@Transactional(readOnly = true)
 	Collection<CohortMember> findCohortMembersByCohortUuid(@NotNull String cohortUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMember> findCohortMembersByPatientUuid(@NotNull String patientUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMember> findCohortMembersByPatientName(@NotNull String patientName);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortMember> findCohortMembersByCohortAndPatientName(@NotNull String cohortUuid,
 	        @NotNull String patientName);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
@@ -20,54 +20,78 @@ import org.openmrs.module.cohort.CohortAttribute;
 import org.openmrs.module.cohort.CohortAttributeType;
 import org.openmrs.module.cohort.CohortM;
 import org.openmrs.module.cohort.CohortType;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CohortService extends OpenmrsService {
 	
+	@Transactional(readOnly = true)
 	CohortM getCohortM(@NotNull String name);
 	
+	@Transactional(readOnly = true)
 	CohortM getCohortM(@NotNull int id);
 	
+	@Transactional(readOnly = true)
 	CohortM getCohortMByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortM> findCohortMByLocationUuid(@NotNull String locationUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortM> findCohortMByPatientUuid(@NotNull String patientUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortM> findAll();
 	
+	@Transactional
 	CohortM saveCohortM(@NotNull CohortM cohortType);
 	
+	@Transactional
 	void voidCohortM(@NotNull CohortM cohort, String reason);
 	
+	@Transactional
 	void purgeCohortM(@NotNull CohortM cohortType);
 	
-	CohortAttribute getAttributeByUuid(@NotNull String uuid);
+	@Transactional(readOnly = true)
+	CohortAttribute getCohortAttributeByUuid(@NotNull String uuid);
 	
-	CohortAttribute saveAttribute(@NotNull CohortAttribute attribute);
+	@Transactional
+	CohortAttribute saveCohortAttribute(@NotNull CohortAttribute attribute);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortAttribute> findCohortAttributesByCohortUuid(@NotNull String cohortUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortAttribute> findCohortAttributesByTypeUuid(@NotNull String attributeTypeUuid);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortAttribute> findCohortAttributesByTypeName(@NotNull String attributeTypeName);
 	
+	@Transactional
 	void voidCohortAttribute(@NotNull CohortAttribute attribute, String retiredReason);
 	
+	@Transactional
 	void purgeCohortAttribute(@NotNull CohortAttribute attribute);
 	
+	@Transactional(readOnly = true)
 	CohortAttributeType getCohortAttributeTypeByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	CohortAttributeType getCohortAttributeTypeByName(@NotNull String name);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortAttributeType> findAllCohortAttributeTypes();
 	
+	@Transactional
 	CohortAttributeType saveCohortAttributeType(@NotNull CohortAttributeType attributeType);
 	
+	@Transactional
 	void voidCohortAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason);
 	
+	@Transactional
 	void purgeCohortAttributeType(@NotNull CohortAttributeType attributeType);
 	
 	//Search
+	@Transactional(readOnly = true)
 	List<CohortM> findMatchingCohortMs(String nameMatching, Map<String, String> attributes, CohortType cohortType,
 	        boolean includeVoided);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortService.java
@@ -23,51 +23,51 @@ import org.openmrs.module.cohort.CohortType;
 
 public interface CohortService extends OpenmrsService {
 	
-	CohortM getCohort(@NotNull String name);
+	CohortM getCohortM(@NotNull String name);
 	
-	CohortM getCohort(@NotNull int id);
+	CohortM getCohortM(@NotNull int id);
 	
-	CohortM getCohortByUuid(@NotNull String uuid);
+	CohortM getCohortMByUuid(@NotNull String uuid);
 	
-	Collection<CohortM> findCohortByLocationUuid(@NotNull String locationUuid);
+	Collection<CohortM> findCohortMByLocationUuid(@NotNull String locationUuid);
 	
-	Collection<CohortM> findCohortByPatientUuid(@NotNull String patientUuid);
+	Collection<CohortM> findCohortMByPatientUuid(@NotNull String patientUuid);
 	
 	Collection<CohortM> findAll();
 	
-	CohortM saveCohort(@NotNull CohortM cohortType);
+	CohortM saveCohortM(@NotNull CohortM cohortType);
 	
 	void voidCohortM(@NotNull CohortM cohort, String reason);
 	
-	void purgeCohort(@NotNull CohortM cohortType);
+	void purgeCohortM(@NotNull CohortM cohortType);
 	
 	CohortAttribute getAttributeByUuid(@NotNull String uuid);
 	
 	CohortAttribute saveAttribute(@NotNull CohortAttribute attribute);
 	
-	Collection<CohortAttribute> findAttributesByCohortUuid(@NotNull String cohortUuid);
+	Collection<CohortAttribute> findCohortAttributesByCohortUuid(@NotNull String cohortUuid);
 	
-	Collection<CohortAttribute> findAttributesByTypeUuid(@NotNull String attributeTypeUuid);
+	Collection<CohortAttribute> findCohortAttributesByTypeUuid(@NotNull String attributeTypeUuid);
 	
-	Collection<CohortAttribute> findAttributesByTypeName(@NotNull String attributeTypeName);
+	Collection<CohortAttribute> findCohortAttributesByTypeName(@NotNull String attributeTypeName);
 	
 	void voidCohortAttribute(@NotNull CohortAttribute attribute, String retiredReason);
 	
 	void purgeCohortAttribute(@NotNull CohortAttribute attribute);
 	
-	CohortAttributeType getAttributeTypeByUuid(@NotNull String uuid);
+	CohortAttributeType getCohortAttributeTypeByUuid(@NotNull String uuid);
 	
-	CohortAttributeType getAttributeTypeByName(@NotNull String name);
+	CohortAttributeType getCohortAttributeTypeByName(@NotNull String name);
 	
-	Collection<CohortAttributeType> findAllAttributeTypes();
+	Collection<CohortAttributeType> findAllCohortAttributeTypes();
 	
-	CohortAttributeType saveAttributeType(@NotNull CohortAttributeType attributeType);
+	CohortAttributeType saveCohortAttributeType(@NotNull CohortAttributeType attributeType);
 	
-	void voidAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason);
+	void voidCohortAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason);
 	
-	void purgeAttributeType(@NotNull CohortAttributeType attributeType);
+	void purgeCohortAttributeType(@NotNull CohortAttributeType attributeType);
 	
 	//Search
-	List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	List<CohortM> findMatchingCohortMs(String nameMatching, Map<String, String> attributes, CohortType cohortType,
 	        boolean includeVoided);
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortTypeService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortTypeService.java
@@ -6,23 +6,32 @@ import java.util.Collection;
 
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.cohort.CohortType;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CohortTypeService extends OpenmrsService {
 	
+	@Transactional(readOnly = true)
 	CohortType getCohortTypeByUuid(@NotNull String uuid);
 	
+	@Transactional(readOnly = true)
 	CohortType getCohortTypeByUuid(@NotNull String uuid, boolean includeVoided);
 	
+	@Transactional(readOnly = true)
 	CohortType getCohortTypeByName(@NotNull String name);
 	
+	@Transactional(readOnly = true)
 	CohortType getCohortTypeByName(@NotNull String name, boolean includeVoided);
 	
+	@Transactional(readOnly = true)
 	Collection<CohortType> findAllCohortTypes();
 	
+	@Transactional
 	CohortType saveCohortType(@NotNull CohortType cohortType);
 	
+	@Transactional
 	void voidCohortType(@NotNull CohortType cohortType, String voidedReason);
 	
+	@Transactional
 	void purgeCohortType(@NotNull CohortType cohortType);
 	
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/CohortTypeService.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/CohortTypeService.java
@@ -9,15 +9,15 @@ import org.openmrs.module.cohort.CohortType;
 
 public interface CohortTypeService extends OpenmrsService {
 	
-	CohortType getByUuid(@NotNull String uuid);
+	CohortType getCohortTypeByUuid(@NotNull String uuid);
 	
-	CohortType getByUuid(@NotNull String uuid, boolean includeVoided);
+	CohortType getCohortTypeByUuid(@NotNull String uuid, boolean includeVoided);
 	
-	CohortType getByName(@NotNull String name);
+	CohortType getCohortTypeByName(@NotNull String name);
 	
-	CohortType getByName(@NotNull String name, boolean includeVoided);
+	CohortType getCohortTypeByName(@NotNull String name, boolean includeVoided);
 	
-	Collection<CohortType> findAll();
+	Collection<CohortType> findAllCohortTypes();
 	
 	CohortType saveCohortType(@NotNull CohortType cohortType);
 	

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/AbstractGenericDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/AbstractGenericDao.java
@@ -64,9 +64,9 @@ public abstract class AbstractGenericDao<W extends OpenmrsObject & Auditable> im
 	}
 	
 	@Override
-	public W get(String uuid, boolean includeRetired) {
+	public W get(String uuid, boolean includeVoided) {
 		Criteria criteria = getCurrentSession().createCriteria(clazz);
-		includeRetiredObjects(criteria, includeRetired);
+		includeDeletedObjects(criteria, includeVoided);
 		return (W) criteria.add(eq("uuid", uuid)).uniqueResult();
 	}
 	
@@ -78,7 +78,7 @@ public abstract class AbstractGenericDao<W extends OpenmrsObject & Auditable> im
 	@Override
 	public Collection<W> findAll(boolean includeRetired) {
 		Criteria criteria = getCurrentSession().createCriteria(clazz);
-		includeRetiredObjects(criteria, includeRetired);
+		includeDeletedObjects(criteria, includeRetired);
 		return criteria.list();
 	}
 	
@@ -112,7 +112,7 @@ public abstract class AbstractGenericDao<W extends OpenmrsObject & Auditable> im
 	@Override
 	public Collection<W> findBy(PropValue propValue, boolean includeRetired) {
 		Criteria criteria = getCurrentSession().createCriteria(clazz);
-		includeRetiredObjects(criteria, includeRetired);
+		includeDeletedObjects(criteria, includeRetired);
 		return propValue.getAssociationPath().isPresent()
 		        ? criteria.createCriteria(propValue.getAssociationPath().get(), "_pv2021")
 		                .add(eq("_pv2021." + propValue.getProperty(), propValue.getValue())).list()
@@ -127,7 +127,7 @@ public abstract class AbstractGenericDao<W extends OpenmrsObject & Auditable> im
 	@Override
 	public W findByUniqueProp(PropValue propValue, boolean includeRetired) {
 		Criteria criteria = getCurrentSession().createCriteria(clazz);
-		includeRetiredObjects(criteria, includeRetired);
+		includeDeletedObjects(criteria, includeRetired);
 		return (W) (propValue.getAssociationPath().isPresent()
 		        ? criteria.createCriteria(propValue.getAssociationPath().get(), "_cu2021")
 		                .add(eq("_cu2021." + propValue.getProperty(), propValue.getValue())).uniqueResult()
@@ -162,8 +162,8 @@ public abstract class AbstractGenericDao<W extends OpenmrsObject & Auditable> im
 		criteria.add(eq("retired", false));
 	}
 	
-	protected void includeRetiredObjects(Criteria criteria, boolean includeRetired) {
-		if (!includeRetired) {
+	protected void includeDeletedObjects(Criteria criteria, boolean includeDeleted) {
+		if (!includeDeleted) {
 			if (isVoidable()) {
 				handleVoidable(criteria);
 			} else if (isRetireable()) {

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/GenericDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/GenericDao.java
@@ -16,20 +16,15 @@ import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.module.cohort.api.dao.search.ISearchQuery;
 import org.openmrs.module.cohort.api.dao.search.PropValue;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 public interface GenericDao<W extends OpenmrsObject & Auditable> {
 	
 	ISearchQuery getSearchHandler();
 	
-	@Transactional(readOnly = true)
 	W get(final int id);
 	
-	@Transactional(readOnly = true)
 	W get(final String uuid);
 	
-	@Transactional(readOnly = true)
 	W get(final String uuid, boolean includeDeleted);
 	
 	W createOrUpdate(W object);
@@ -38,28 +33,20 @@ public interface GenericDao<W extends OpenmrsObject & Auditable> {
 	
 	void delete(String uuid);
 	
-	@Transactional(readOnly = true)
 	Collection<W> findAll();
 	
-	@Transactional(readOnly = true)
 	Collection<W> findAll(boolean includeRetired);
 	
-	@Transactional(readOnly = true)
 	Collection<W> findBy(PropValue propValue);
 	
-	@Transactional(readOnly = true)
 	Collection<W> findBy(PropValue propValue, boolean includeRetired);
 	
-	@Transactional(readOnly = true)
 	W findByUniqueProp(PropValue propValue);
 	
-	@Transactional(readOnly = true)
 	W findByUniqueProp(PropValue propValue, boolean includeRetired);
 	
-	@Transactional(readOnly = true)
 	Collection<W> findByOr(Criterion... predicates);
 	
-	@Transactional(readOnly = true)
 	Collection<W> findByAnd(Criterion... predicates);
 	
 }

--- a/api/src/main/java/org/openmrs/module/cohort/api/dao/GenericDao.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/dao/GenericDao.java
@@ -30,7 +30,7 @@ public interface GenericDao<W extends OpenmrsObject & Auditable> {
 	W get(final String uuid);
 	
 	@Transactional(readOnly = true)
-	W get(final String uuid, boolean includeRetired);
+	W get(final String uuid, boolean includeDeleted);
 	
 	W createOrUpdate(W object);
 	

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImpl.java
@@ -45,98 +45,97 @@ public class CohortMemberServiceImpl extends BaseOpenmrsService implements Cohor
 	
 	@Override
 	@Transactional(readOnly = true)
-	public CohortMember getByUuid(@NotNull String uuid) {
+	public CohortMember getCohortMemberByUuid(@NotNull String uuid) {
 		return cohortMemberDao.get(uuid);
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public CohortMember getByName(String name) {
+	public CohortMember getCohortMemberByName(String name) {
 		return cohortMemberDao.findByUniqueProp(PropValue.builder().property("name").value(name).build());
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public Collection<CohortMember> findAll() {
+	public Collection<CohortMember> findAllCohortMembers() {
 		return cohortMemberDao.findAll();
 	}
 	
 	@Override
-	public CohortMember createOrUpdate(CohortMember cohortMember) {
+	public CohortMember saveCohortMember(CohortMember cohortMember) {
 		return cohortMemberDao.createOrUpdate(cohortMember);
 	}
 	
 	@Override
-	public CohortMember voidCohortMember(CohortMember cohortMember, String voidReason) {
+	public void voidCohortMember(CohortMember cohortMember, String voidReason) {
 		if (cohortMember == null) {
-			return null;
+			return;
 		}
 		
-		return cohortMemberDao.createOrUpdate(cohortMember);
+		cohortMemberDao.createOrUpdate(cohortMember);
 	}
 	
 	@Override
-	public void purge(CohortMember cohortMember) {
+	public void purgeCohortMember(CohortMember cohortMember) {
 		cohortMemberDao.delete(cohortMember);
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public CohortMemberAttributeType getAttributeTypeByUuid(String uuid) {
+	public CohortMemberAttributeType getCohortMemberAttributeTypeByUuid(String uuid) {
 		return cohortMemberAttributeTypeDao.get(uuid);
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public Collection<CohortMemberAttributeType> findAllAttributeTypes() {
+	public Collection<CohortMemberAttributeType> findAllCohortMemberAttributeTypes() {
 		return cohortMemberAttributeTypeDao.findAll();
 	}
 	
 	@Override
-	public CohortMemberAttributeType createAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
+	public CohortMemberAttributeType saveCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
 		return cohortMemberAttributeTypeDao.createOrUpdate(cohortMemberAttributeType);
 	}
 	
 	@Override
-	public CohortMemberAttributeType voidAttributeType(CohortMemberAttributeType cohortMemberAttributeType,
-	        String voidReason) {
+	public void voidCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType, String voidReason) {
 		cohortMemberAttributeType.setRetired(true);
 		cohortMemberAttributeType.setRetireReason(voidReason);
-		return cohortMemberAttributeTypeDao.createOrUpdate(cohortMemberAttributeType);
+		cohortMemberAttributeTypeDao.createOrUpdate(cohortMemberAttributeType);
 	}
 	
 	@Override
-	public void purgeAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
+	public void purgeCohortMemberAttributeType(CohortMemberAttributeType cohortMemberAttributeType) {
 		cohortMemberAttributeTypeDao.delete(cohortMemberAttributeType);
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public CohortMemberAttribute getAttributeByUuid(@NotNull String uuid) {
+	public CohortMemberAttribute getCohortMemberAttributeByUuid(@NotNull String uuid) {
 		return cohortMemberAttributeDao.get(uuid);
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
-	public Collection<CohortMemberAttribute> getAttributeByTypeUuid(@NotNull String uuid) {
+	public Collection<CohortMemberAttribute> getCohortMemberAttributesByTypeUuid(@NotNull String uuid) {
 		return cohortMemberAttributeDao.findBy(
 		    PropValue.builder().property("uuid").associationPath(Optional.of("attributeType")).value(uuid).build());
 	}
 	
 	@Override
-	public CohortMemberAttribute createAttribute(CohortMemberAttribute cohortMemberAttribute) {
+	public CohortMemberAttribute saveCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
 		return cohortMemberAttributeDao.createOrUpdate(cohortMemberAttribute);
 	}
 	
 	@Override
-	public CohortMemberAttribute deleteAttribute(CohortMemberAttribute attribute, String voidReason) {
+	public void voidCohortMemberAttribute(CohortMemberAttribute attribute, String voidReason) {
 		attribute.setVoided(true);
 		attribute.setVoidReason(voidReason);
-		return cohortMemberAttributeDao.createOrUpdate(attribute);
+		cohortMemberAttributeDao.createOrUpdate(attribute);
 	}
 	
 	@Override
-	public void purgeAttribute(CohortMemberAttribute cohortMemberAttribute) {
+	public void purgeCohortMemberAttribute(CohortMemberAttribute cohortMemberAttribute) {
 		cohortMemberAttributeDao.delete(cohortMemberAttribute);
 	}
 	
@@ -162,7 +161,7 @@ public class CohortMemberServiceImpl extends BaseOpenmrsService implements Cohor
 	
 	@Override
 	@Transactional(readOnly = true)
-	public Collection<CohortMember> findCohortMembersByCohortAndPatient(@NotNull String cohortUuid,
+	public Collection<CohortMember> findCohortMembersByCohortAndPatientName(@NotNull String cohortUuid,
 	        @NotNull String patientName) {
 		return cohortMemberDao.getSearchHandler().findCohortMembersByCohortAndPatient(cohortUuid, patientName);
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -48,28 +48,28 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public CohortM getCohortByUuid(@NotNull String uuid) {
+	public CohortM getCohortMByUuid(@NotNull String uuid) {
 		return cohortDao.get(uuid);
 	}
 	
 	@Override
-	public CohortM getCohort(@NotNull String name) {
+	public CohortM getCohortM(@NotNull String name) {
 		return cohortDao.findByUniqueProp(PropValue.builder().property("name").value(name).build());
 	}
 	
 	@Override
-	public CohortM getCohort(int id) {
+	public CohortM getCohortM(int id) {
 		return cohortDao.get(id);
 	}
 	
 	@Override
-	public Collection<CohortM> findCohortByLocationUuid(@NotNull String locationUuid) {
+	public Collection<CohortM> findCohortMByLocationUuid(@NotNull String locationUuid) {
 		return cohortDao.findBy(
 		    PropValue.builder().property("uuid").associationPath(Optional.of("location")).value(locationUuid).build());
 	}
 	
 	@Override
-	public Collection<CohortM> findCohortByPatientUuid(@NotNull String patientUuid) {
+	public Collection<CohortM> findCohortMByPatientUuid(@NotNull String patientUuid) {
 		return cohortDao.findBy(
 		    PropValue.builder().property("uuid").associationPath(Optional.of("patient")).value(patientUuid).build());
 	}
@@ -80,7 +80,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public CohortM saveCohort(@NotNull CohortM cohortM) {
+	public CohortM saveCohortM(@NotNull CohortM cohortM) {
 		return cohortDao.createOrUpdate(cohortM);
 	}
 	
@@ -94,7 +94,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public void purgeCohort(@NotNull CohortM cohort) {
+	public void purgeCohortM(@NotNull CohortM cohort) {
 		cohortDao.delete(cohort);
 	}
 	
@@ -109,19 +109,19 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public Collection<CohortAttribute> findAttributesByCohortUuid(String cohortUuid) {
+	public Collection<CohortAttribute> findCohortAttributesByCohortUuid(String cohortUuid) {
 		return cohortAttributeDao.findBy(
 		    PropValue.builder().associationPath(Optional.of("cohort")).property("uuid").value(cohortUuid).build());
 	}
 	
 	@Override
-	public Collection<CohortAttribute> findAttributesByTypeUuid(String attributeTypeUuid) {
+	public Collection<CohortAttribute> findCohortAttributesByTypeUuid(String attributeTypeUuid) {
 		return cohortAttributeDao.findBy(PropValue.builder().associationPath(Optional.of("attributeType")).property("uuid")
 		        .value(attributeTypeUuid).build());
 	}
 	
 	@Override
-	public Collection<CohortAttribute> findAttributesByTypeName(String attributeTypeName) {
+	public Collection<CohortAttribute> findCohortAttributesByTypeName(String attributeTypeName) {
 		return cohortAttributeDao.findBy(PropValue.builder().associationPath(Optional.of("attributeType")).property("name")
 		        .value(attributeTypeName).build());
 	}
@@ -141,27 +141,27 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public CohortAttributeType getAttributeTypeByUuid(@NotNull String uuid) {
+	public CohortAttributeType getCohortAttributeTypeByUuid(@NotNull String uuid) {
 		return cohortAttributeTypeDao.get(uuid);
 	}
 	
 	@Override
-	public CohortAttributeType getAttributeTypeByName(String name) {
+	public CohortAttributeType getCohortAttributeTypeByName(String name) {
 		return cohortAttributeTypeDao.findByUniqueProp(PropValue.builder().property("name").value(name).build());
 	}
 	
 	@Override
-	public Collection<CohortAttributeType> findAllAttributeTypes() {
+	public Collection<CohortAttributeType> findAllCohortAttributeTypes() {
 		return cohortAttributeTypeDao.findAll();
 	}
 	
 	@Override
-	public CohortAttributeType saveAttributeType(@NotNull CohortAttributeType attributeType) {
+	public CohortAttributeType saveCohortAttributeType(@NotNull CohortAttributeType attributeType) {
 		return cohortAttributeTypeDao.createOrUpdate(attributeType);
 	}
 	
 	@Override
-	public void voidAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason) {
+	public void voidCohortAttributeType(@NotNull CohortAttributeType attributeType, String retiredReason) {
 		if (attributeType == null) {
 			return;
 		}
@@ -170,12 +170,12 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public void purgeAttributeType(@NotNull CohortAttributeType attributeType) {
+	public void purgeCohortAttributeType(@NotNull CohortAttributeType attributeType) {
 		cohortAttributeTypeDao.delete(attributeType);
 	}
 	
 	@Override
-	public List<CohortM> findMatchingCohorts(String nameMatching, Map<String, String> attributes, CohortType cohortType,
+	public List<CohortM> findMatchingCohortMs(String nameMatching, Map<String, String> attributes, CohortType cohortType,
 	        boolean includeVoided) {
 		return cohortDao.getSearchHandler().findCohorts(nameMatching, attributes, cohortType, includeVoided);
 	}

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortServiceImpl.java
@@ -99,12 +99,12 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	}
 	
 	@Override
-	public CohortAttribute getAttributeByUuid(@NotNull String uuid) {
+	public CohortAttribute getCohortAttributeByUuid(@NotNull String uuid) {
 		return cohortAttributeDao.get(uuid);
 	}
 	
 	@Override
-	public CohortAttribute saveAttribute(@NotNull CohortAttribute attribute) {
+	public CohortAttribute saveCohortAttribute(@NotNull CohortAttribute attribute) {
 		return cohortAttributeDao.createOrUpdate(attribute);
 	}
 	

--- a/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortTypeServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/cohort/api/impl/CohortTypeServiceImpl.java
@@ -24,27 +24,27 @@ public class CohortTypeServiceImpl extends BaseOpenmrsService implements CohortT
 	}
 	
 	@Override
-	public CohortType getByUuid(@NotNull String uuid) {
-		return getByUuid(uuid, false);
+	public CohortType getCohortTypeByUuid(@NotNull String uuid) {
+		return getCohortTypeByUuid(uuid, false);
 	}
 	
 	@Override
-	public CohortType getByUuid(String uuid, boolean includeVoided) {
+	public CohortType getCohortTypeByUuid(String uuid, boolean includeVoided) {
 		return dao.get(uuid, includeVoided);
 	}
 	
 	@Override
-	public CohortType getByName(@NotNull String name) {
-		return getByName(name, false);
+	public CohortType getCohortTypeByName(@NotNull String name) {
+		return getCohortTypeByName(name, false);
 	}
 	
 	@Override
-	public CohortType getByName(String name, boolean includeVoided) {
+	public CohortType getCohortTypeByName(String name, boolean includeVoided) {
 		return dao.findByUniqueProp(PropValue.builder().property("name").value(name).build(), includeVoided);
 	}
 	
 	@Override
-	public Collection<CohortType> findAll() {
+	public Collection<CohortType> findAllCohortTypes() {
 		return dao.findAll();
 	}
 	

--- a/api/src/main/java/org/openmrs/module/cohort/validators/CohortAttributeTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validators/CohortAttributeTypeValidator.java
@@ -35,7 +35,7 @@ public class CohortAttributeTypeValidator extends BaseAttributeTypeValidator<Coh
 		
 		CohortAttributeType cohortAttributeType = (CohortAttributeType) command;
 		CohortAttributeType attributeType = Context.getService(CohortService.class)
-		        .getAttributeTypeByName(cohortAttributeType.getName());
+		        .getCohortAttributeTypeByName(cohortAttributeType.getName());
 		
 		if (attributeType != null) {
 			errors.rejectValue("name", " A cohort attribute type with the same name already exists");

--- a/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validators/CohortMValidator.java
@@ -44,7 +44,7 @@ public class CohortMValidator implements Validator {
 		CohortM cohort = (CohortM) command;
 		
 		// Cohort should have a unique name
-		CohortM cohortByName = Context.getService(CohortService.class).getCohort(cohort.getName());
+		CohortM cohortByName = Context.getService(CohortService.class).getCohortM(cohort.getName());
 		if (cohortByName != null && cohortByName.getId() != cohort.getId()) {
 			errors.rejectValue("name", "A cohort with this name already exists");
 		}

--- a/api/src/main/java/org/openmrs/module/cohort/validators/CohortTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/cohort/validators/CohortTypeValidator.java
@@ -35,7 +35,7 @@ public class CohortTypeValidator implements Validator {
 		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "required");
 		
 		CohortType currentType = (CohortType) command;
-		CohortType type = Context.getService(CohortTypeService.class).getByName(currentType.getName());
+		CohortType type = Context.getService(CohortTypeService.class).getCohortTypeByName(currentType.getName());
 		
 		if (type != null) {
 			errors.rejectValue("name", "A cohort type with the same name already exists");

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortMemberAttributeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortMemberAttributeGenericDaoTest.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Optional;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.cohort.CohortMemberAttribute;
 import org.openmrs.module.cohort.api.TestDataUtils;
@@ -29,7 +28,6 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-@Ignore
 public class CohortMemberAttributeGenericDaoTest extends BaseModuleContextSensitiveTest {
 	
 	//The order is salient
@@ -81,6 +79,7 @@ public class CohortMemberAttributeGenericDaoTest extends BaseModuleContextSensit
 	@Test
 	public void shouldCreateNewCohortMemberAttribute() {
 		CohortMemberAttribute cohortAttribute = dao.createOrUpdate(TestDataUtils.COHORT_MEMBER_ATTRIBUTE());
+		
 		assertThat(cohortAttribute, notNullValue());
 		assertThat(cohortAttribute.getId(), notNullValue());
 		assertThat(cohortAttribute.getId(), equalTo(TEST_COHORT_MEMBER_ATTRIBUTE_ID));
@@ -94,7 +93,7 @@ public class CohortMemberAttributeGenericDaoTest extends BaseModuleContextSensit
 		attributeToVoid.setVoidReason("Voided via cohort rest call");
 		dao.createOrUpdate(attributeToVoid);
 		
-		CohortMemberAttribute attribute = dao.get(COHORT_MEMBER_ATTRIBUTE_UUID);
+		CohortMemberAttribute attribute = dao.get(COHORT_MEMBER_ATTRIBUTE_UUID, true);
 		
 		assertThat(attribute, notNullValue());
 		assertThat(attribute.getVoided(), is(true));

--- a/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortMemberAttributeTypeGenericDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/dao/CohortMemberAttributeTypeGenericDaoTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.nullValue;
 import java.util.Collection;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.cohort.CohortMemberAttributeType;
 import org.openmrs.module.cohort.api.TestDataUtils;
@@ -29,7 +28,6 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-@Ignore
 public class CohortMemberAttributeTypeGenericDaoTest extends BaseModuleContextSensitiveTest {
 	
 	String COHORT_MEMBER_ATTRIBUTE_TYPE_INITIAL_TEST_DATA_XML = "org/openmrs/module/cohort/api/hibernate/db/CohortMemberAttributeTypeDaoTest_initialTestData.xml";
@@ -62,7 +60,7 @@ public class CohortMemberAttributeTypeGenericDaoTest extends BaseModuleContextSe
 		Collection<CohortMemberAttributeType> attributeTypes = dao.findAll();
 		
 		assertThat(attributeTypes, notNullValue());
-		assertThat(attributeTypes, hasSize(2));
+		assertThat(attributeTypes, hasSize(1));
 		assertThat(attributeTypes, everyItem(hasProperty("name", notNullValue())));
 	}
 	
@@ -83,7 +81,8 @@ public class CohortMemberAttributeTypeGenericDaoTest extends BaseModuleContextSe
 		attributeTypeToRetire.setRetired(true);
 		dao.createOrUpdate(attributeTypeToRetire);
 		
-		CohortMemberAttributeType attributeType = dao.get(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		CohortMemberAttributeType attributeType = dao.get(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID, true);
+		
 		assertThat(attributeType, notNullValue());
 		assertThat(attributeType.getRetired(), is(true));
 		assertThat(attributeType.getRetireReason(), is("Voided via cohort rest call"));

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortMemberServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -59,7 +60,8 @@ public class CohortMemberServiceImplTest {
 		when(cohortMemberAttributeTypeDao.get(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID)).thenReturn(cohortMemberAttributeType);
 		when(cohortMemberAttributeType.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
 		
-		CohortMemberAttributeType result = cohortMemberService.getAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
+		CohortMemberAttributeType result = cohortMemberService
+		        .getCohortMemberAttributeTypeByUuid(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID);
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_TYPE_UUID));
 	}
@@ -74,13 +76,19 @@ public class CohortMemberServiceImplTest {
 		when(cohortMemberAttributeTypeDao.createOrUpdate(cohortMemberAttributeType)).thenReturn(cohortMemberAttributeType);
 		when(cohortMemberAttributeType.getId()).thenReturn(1);
 		
-		CohortMemberAttributeType result = cohortMemberService.createAttributeType(cohortMemberAttributeType);
+		CohortMemberAttributeType result = cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
+		
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), is(1));
 	}
 	
 	@Test
 	public void purgeCohortMemberAttributeType() {
+		CohortMemberAttributeType cohortMemberAttributeType = mock(CohortMemberAttributeType.class);
+		
+		cohortMemberService.purgeCohortMemberAttributeType(cohortMemberAttributeType);
+		
+		verify(cohortMemberAttributeTypeDao).delete(cohortMemberAttributeType);
 	}
 	
 	@Test
@@ -89,7 +97,7 @@ public class CohortMemberServiceImplTest {
 		when(cohortMemberAttributeDao.get(COHORT_MEMBER_ATTRIBUTE_UUID)).thenReturn(cohortMemberAttribute);
 		when(cohortMemberAttribute.getUuid()).thenReturn(COHORT_MEMBER_ATTRIBUTE_UUID);
 		
-		CohortMemberAttribute result = cohortMemberService.getAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
+		CohortMemberAttribute result = cohortMemberService.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID);
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), is(COHORT_MEMBER_ATTRIBUTE_UUID));
 	}
@@ -100,7 +108,8 @@ public class CohortMemberServiceImplTest {
 		when(cohortMemberAttributeDao.createOrUpdate(cohortMemberAttribute)).thenReturn(cohortMemberAttribute);
 		when(cohortMemberAttribute.getId()).thenReturn(1);
 		
-		CohortMemberAttribute result = cohortMemberService.createAttribute(cohortMemberAttribute);
+		CohortMemberAttribute result = cohortMemberService.saveCohortMemberAttribute(cohortMemberAttribute);
+		
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), is(1));
 	}

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplContextSensitiveTest.java
@@ -22,34 +22,36 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 	}
 	
 	@Test
-	public void saveCohort_shouldSaveCohort() {
+	public void saveCohortM_shouldSaveCohort() {
 		CohortM cohortM = new CohortM();
+		cohortM.setName("Test Cohort");
 		cohortM.setCohortType(new CohortType());
 		
-		CohortM result = Context.getService(CohortService.class).saveCohort(cohortM);
+		CohortM result = Context.getService(CohortService.class).saveCohortM(cohortM);
 		
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), notNullValue());
 	}
 	
 	@Test
-	public void saveCohort_shouldUpdateCohort() {
+	public void saveCohortM_shouldUpdateCohort() {
 		CohortM cohortM = new CohortM();
 		cohortM.setName("Test Cohort");
 		cohortM.setCohortType(new CohortType());
 		
-		CohortM savedCohort = Context.getService(CohortService.class).saveCohort(cohortM);
+		CohortM savedCohort = Context.getService(CohortService.class).saveCohortM(cohortM);
 		savedCohort.setName("Updated Test Cohort");
 		
-		CohortM result = Context.getService(CohortService.class).saveCohort(savedCohort);
+		CohortM result = Context.getService(CohortService.class).saveCohortM(savedCohort);
 		
 		assertThat(result, notNullValue());
 		assertThat(result.getName(), equalTo("Updated Test Cohort"));
 	}
 	
 	@Test
-	public void saveCohort_shouldSaveCohortMembers() {
+	public void saveCohortM_shouldSaveCohortMembers() {
 		CohortM cohortM = new CohortM();
+		cohortM.setName("Test Cohort");
 		cohortM.setCohortType(new CohortType());
 		
 		Patient patient = Context.getPatientService().getPatient(7);
@@ -57,7 +59,7 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 		
 		cohortM.addMemberships(cm);
 		
-		CohortM result = Context.getService(CohortService.class).saveCohort(cohortM);
+		CohortM result = Context.getService(CohortService.class).saveCohortM(cohortM);
 		
 		assertThat(result, notNullValue());
 		assertThat(result.size(), equalTo(1));
@@ -66,20 +68,21 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 	}
 	
 	@Test
-	public void saveCohort_shouldSaveCohortMembersForExistingCohort() {
+	public void saveCohortM_shouldSaveCohortMembersForExistingCohort() {
 		CohortM cohortM = new CohortM();
+		cohortM.setName("Test Cohort");
 		cohortM.setCohortType(new CohortType());
 		
-		CohortM savedCohort = Context.getService(CohortService.class).saveCohort(cohortM);
+		CohortM savedCohort = Context.getService(CohortService.class).saveCohortM(cohortM);
 		
 		Patient patient = Context.getPatientService().getPatient(7);
 		CohortMember cm = new CohortMember(patient);
 		savedCohort.addMemberships(cm);
 		
-		Context.getService(CohortService.class).saveCohort(savedCohort);
+		Context.getService(CohortService.class).saveCohortM(savedCohort);
 		Context.getRegisteredComponent("sessionFactory", SessionFactory.class).getCurrentSession().flush();
 		
-		CohortM result = Context.getService(CohortService.class).getCohort(savedCohort.getCohortId());
+		CohortM result = Context.getService(CohortService.class).getCohortM(savedCohort.getCohortId());
 		
 		assertThat(result, notNullValue());
 		assertThat(result.size(), equalTo(1));
@@ -88,8 +91,9 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 	}
 	
 	@Test
-	public void saveCohort_shouldRemoveMembersForExistingCohort() {
+	public void saveCohortM_shouldRemoveMembersForExistingCohort() {
 		CohortM cohortM = new CohortM();
+		cohortM.setName("Test Cohort");
 		cohortM.setCohortType(new CohortType());
 		
 		Patient patient = Context.getPatientService().getPatient(7);
@@ -97,11 +101,11 @@ public class CohortServiceImplContextSensitiveTest extends BaseModuleContextSens
 		
 		cohortM.addMemberships(cm);
 		
-		CohortM existingCohort = Context.getService(CohortService.class).saveCohort(cohortM);
+		CohortM existingCohort = Context.getService(CohortService.class).saveCohortM(cohortM);
 		
 		existingCohort.removeMemberships(existingCohort.getActiveCohortMembers().iterator().next());
 		
-		CohortM result = Context.getService(CohortService.class).saveCohort(existingCohort);
+		CohortM result = Context.getService(CohortService.class).saveCohortM(existingCohort);
 		
 		assertThat(result, notNullValue());
 		assertThat(result.size(), equalTo(0));

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
@@ -99,7 +99,7 @@ public class CohortServiceImplTest {
 		when(cohortAttribute.getCohortAttributeId()).thenReturn(345);
 		when(cohortAttributeDao.createOrUpdate(cohortAttribute)).thenReturn(cohortAttribute);
 		
-		CohortAttribute attribute = cohortService.saveAttribute(cohortAttribute);
+		CohortAttribute attribute = cohortService.saveCohortAttribute(cohortAttribute);
 		assertThat(attribute, notNullValue());
 		assertThat(attribute.getCohortAttributeId(), equalTo(345));
 	}
@@ -124,7 +124,7 @@ public class CohortServiceImplTest {
 		when(cohortAttribute.getUuid()).thenReturn(COHORT_ATTRIBUTE_UUID);
 		when(cohortAttributeDao.get(COHORT_ATTRIBUTE_UUID)).thenReturn(cohortAttribute);
 		
-		CohortAttribute result = cohortService.getAttributeByUuid(COHORT_ATTRIBUTE_UUID);
+		CohortAttribute result = cohortService.getCohortAttributeByUuid(COHORT_ATTRIBUTE_UUID);
 		assertThat(result, notNullValue());
 		assertThat(result.getCohortAttributeId(), equalTo(12));
 		assertThat(result.getUuid(), equalTo(COHORT_ATTRIBUTE_UUID));

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortServiceImplTest.java
@@ -65,7 +65,7 @@ public class CohortServiceImplTest {
 		
 		when(cohortDao.createOrUpdate(cohortM)).thenReturn(cohortM);
 		
-		CohortM result = cohortService.saveCohort(cohortM);
+		CohortM result = cohortService.saveCohortM(cohortM);
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), equalTo(12));
 	}
@@ -76,7 +76,7 @@ public class CohortServiceImplTest {
 		
 		when(cohortAttributeTypeDao.findAll()).thenReturn(Collections.singletonList(attributeType));
 		
-		Collection<CohortAttributeType> allAttributeTypes = cohortService.findAllAttributeTypes();
+		Collection<CohortAttributeType> allAttributeTypes = cohortService.findAllCohortAttributeTypes();
 		assertThat(allAttributeTypes, notNullValue());
 		assertThat(allAttributeTypes.size(), equalTo(1));
 	}
@@ -111,7 +111,7 @@ public class CohortServiceImplTest {
 		when(cohortM.getUuid()).thenReturn(COHORT_UUID);
 		when(cohortDao.get(COHORT_UUID)).thenReturn(cohortM);
 		
-		CohortM result = cohortService.getCohortByUuid(COHORT_UUID);
+		CohortM result = cohortService.getCohortMByUuid(COHORT_UUID);
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(COHORT_UUID));
 	}
@@ -141,7 +141,7 @@ public class CohortServiceImplTest {
 		    PropValue.builder().associationPath(Optional.of("location")).property("uuid").value(locationUuid).build()))
 		            .thenReturn(Collections.singletonList(cohort));
 		
-		Collection<CohortM> cohortsByLocationUuid = cohortService.findCohortByLocationUuid(locationUuid);
+		Collection<CohortM> cohortsByLocationUuid = cohortService.findCohortMByLocationUuid(locationUuid);
 		assertThat(cohortsByLocationUuid, notNullValue());
 		assertThat(cohortsByLocationUuid, hasSize(1));
 		

--- a/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/cohort/api/impl/CohortValidatorTest.java
@@ -24,7 +24,7 @@ public class CohortValidatorTest extends BaseModuleContextSensitiveTest {
 		CohortM cohort = new CohortM();
 		cohort.setCohortType(new CohortType());
 		cohort.setName("Test Cohort");
-		Context.getService(CohortService.class).saveCohort(cohort);
+		Context.getService(CohortService.class).saveCohortM(cohort);
 		
 		CohortM invalidCohort = new CohortM();
 		invalidCohort.setCohortType(new CohortType());
@@ -40,7 +40,7 @@ public class CohortValidatorTest extends BaseModuleContextSensitiveTest {
 		CohortM cohort = new CohortM();
 		cohort.setName("Test Cohort");
 		cohort.setCohortType(new CohortType());
-		Context.getService(CohortService.class).saveCohort(cohort);
+		Context.getService(CohortService.class).saveCohortM(cohort);
 		cohort.setDescription("Updated Cohort description");
 		Errors errors = new BeanPropertyBindingResult(cohort, "invalid cohort");
 		validator.validate(cohort, errors);

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeResource.java
@@ -85,7 +85,7 @@ public class CohortAttributeResource extends BaseAttributeCrudResource1_9<Cohort
 	
 	@Override
 	public CohortAttribute save(CohortAttribute cohortAttribute) {
-		return cohortService.saveAttribute(cohortAttribute);
+		return cohortService.saveCohortAttribute(cohortAttribute);
 	}
 	
 	@Override
@@ -105,7 +105,7 @@ public class CohortAttributeResource extends BaseAttributeCrudResource1_9<Cohort
 	
 	@Override
 	public CohortAttribute getByUniqueId(@NotNull String uuid) {
-		return cohortService.getAttributeByUuid(uuid);
+		return cohortService.getCohortAttributeByUuid(uuid);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResource.java
@@ -29,12 +29,12 @@ public class CohortAttributeTypeResource extends BaseAttributeTypeCrudResource1_
 	
 	@Override
 	public CohortAttributeType save(CohortAttributeType cohortAttributeType) {
-		return Context.getService(CohortService.class).saveAttributeType(cohortAttributeType);
+		return Context.getService(CohortService.class).saveCohortAttributeType(cohortAttributeType);
 	}
 	
 	@Override
 	public void purge(CohortAttributeType cohortAttributeType, RequestContext context) throws ResponseException {
-		Context.getService(CohortService.class).purgeAttributeType(cohortAttributeType);
+		Context.getService(CohortService.class).purgeCohortAttributeType(cohortAttributeType);
 	}
 	
 	@Override
@@ -44,11 +44,12 @@ public class CohortAttributeTypeResource extends BaseAttributeTypeCrudResource1_
 	
 	@Override
 	public CohortAttributeType getByUniqueId(String uuid) {
-		return Context.getService(CohortService.class).getAttributeTypeByUuid(uuid);
+		return Context.getService(CohortService.class).getCohortAttributeTypeByUuid(uuid);
 	}
 	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-		return new NeedsPaging<>(new ArrayList<>(Context.getService(CohortService.class).findAllAttributeTypes()), context);
+		return new NeedsPaging<>(new ArrayList<>(Context.getService(CohortService.class).findAllCohortAttributeTypes()),
+		        context);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResource.java
@@ -46,18 +46,18 @@ public class CohortMemberAttributeResource extends BaseAttributeCrudResource1_9<
 	
 	@Override
 	public CohortMemberAttribute getByUniqueId(String uuid) {
-		return Context.getService(CohortMemberService.class).getAttributeByUuid(uuid);
+		return Context.getService(CohortMemberService.class).getCohortMemberAttributeByUuid(uuid);
 	}
 	
 	@Override
 	public CohortMemberAttribute save(CohortMemberAttribute cohortMemberAttribute) {
-		return Context.getService(CohortMemberService.class).createAttribute(cohortMemberAttribute);
+		return Context.getService(CohortMemberService.class).saveCohortMemberAttribute(cohortMemberAttribute);
 	}
 	
 	@Override
 	protected void delete(CohortMemberAttribute cohortMemberAttribute, String reason, RequestContext requestContext)
 	        throws ResponseException {
-		Context.getService(CohortMemberService.class).deleteAttribute(cohortMemberAttribute, reason);
+		Context.getService(CohortMemberService.class).voidCohortMemberAttribute(cohortMemberAttribute, reason);
 	}
 	
 	@Override
@@ -67,10 +67,7 @@ public class CohortMemberAttributeResource extends BaseAttributeCrudResource1_9<
 	
 	@Override
 	public void purge(CohortMemberAttribute cohortMemberAttribute, RequestContext requestContext) throws ResponseException {
-		boolean purge = Boolean.getBoolean(requestContext.getParameter("purge"));
-		if (purge) {
-			Context.getService(CohortMemberService.class).purgeAttribute(cohortMemberAttribute);
-		}
+		Context.getService(CohortMemberService.class).purgeCohortMemberAttribute(cohortMemberAttribute);
 	}
 	
 	@PropertySetter("attributeType")

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeTypeResource.java
@@ -41,33 +41,34 @@ public class CohortMemberAttributeTypeResource extends BaseAttributeTypeCrudReso
 	
 	@Override
 	public CohortMemberAttributeType getByUniqueId(String uuid) {
-		return cohortMemberService.getAttributeTypeByUuid(uuid);
+		return cohortMemberService.getCohortMemberAttributeTypeByUuid(uuid);
 	}
 	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-		return new NeedsPaging<>((List<CohortMemberAttributeType>) cohortMemberService.findAllAttributeTypes(), context);
+		return new NeedsPaging<>((List<CohortMemberAttributeType>) cohortMemberService.findAllCohortMemberAttributeTypes(),
+		        context);
 	}
 	
 	@Override
 	public CohortMemberAttributeType save(CohortMemberAttributeType cohortMemberAttributeType) {
-		return cohortMemberService.createAttributeType(cohortMemberAttributeType);
+		return cohortMemberService.saveCohortMemberAttributeType(cohortMemberAttributeType);
 	}
 	
 	@Override
 	public void delete(String uuid, String reason, RequestContext context) throws ResponseException {
-		cohortMemberService.voidAttributeType(getByUniqueId(uuid), reason);
+		cohortMemberService.voidCohortMemberAttributeType(getByUniqueId(uuid), reason);
 	}
 	
 	@Override
 	public void delete(CohortMemberAttributeType cohortMemberAttributeType, String voidReason, RequestContext requestContext)
 	        throws ResponseException {
-		cohortMemberService.voidAttributeType(cohortMemberAttributeType, voidReason);
+		cohortMemberService.voidCohortMemberAttributeType(cohortMemberAttributeType, voidReason);
 	}
 	
 	@Override
 	public void purge(CohortMemberAttributeType cohortMemberAttributeType, RequestContext requestContext)
 	        throws ResponseException {
-		cohortMemberService.purgeAttributeType(cohortMemberAttributeType);
+		cohortMemberService.purgeCohortMemberAttributeType(cohortMemberAttributeType);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortMemberResource.java
@@ -119,7 +119,7 @@ public class CohortMemberResource extends DataDelegatingCrudResource<CohortMembe
 				}
 			}
 		}
-		return Context.getService(CohortMemberService.class).createOrUpdate(cohortMember);
+		return Context.getService(CohortMemberService.class).saveCohortMember(cohortMember);
 	}
 	
 	@Override
@@ -129,14 +129,14 @@ public class CohortMemberResource extends DataDelegatingCrudResource<CohortMembe
 	
 	@Override
 	public CohortMember getByUniqueId(String uuid) {
-		return Context.getService(CohortMemberService.class).getByUuid(uuid);
+		return Context.getService(CohortMemberService.class).getCohortMemberByUuid(uuid);
 	}
 	
 	@Override
 	public void purge(CohortMember cohortMember, RequestContext context) throws ResponseException {
 		boolean purge = Boolean.getBoolean(context.getParameter("purge"));
 		if (purge) {
-			Context.getService(CohortMemberService.class).purge(cohortMember);
+			Context.getService(CohortMemberService.class).purgeCohortMember(cohortMember);
 		} else {
 			Context.getService(CohortMemberService.class).voidCohortMember(cohortMember, "");
 		}
@@ -169,7 +169,7 @@ public class CohortMemberResource extends DataDelegatingCrudResource<CohortMembe
 		
 		if (isNotBlank(cohortUuid) && isNotBlank(query)) {
 			Collection<CohortMember> cohortMembers = Context.getService(CohortMemberService.class)
-			        .findCohortMembersByCohortAndPatient(cohortUuid, query);
+			        .findCohortMembersByCohortAndPatientName(cohortUuid, query);
 			return new NeedsPaging<>(new ArrayList<>(cohortMembers), context);
 		} else if (isNotBlank(cohortUuid)) {
 			return new NeedsPaging<>(

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortResource.java
@@ -132,7 +132,7 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 				cohortMember.setEndDate(cohort.getEndDate());
 			}
 		}
-		return Context.getService(CohortService.class).saveCohort(cohort);
+		return Context.getService(CohortService.class).saveCohortM(cohort);
 	}
 	
 	@Override
@@ -142,7 +142,7 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 	
 	@Override
 	public void purge(CohortM cohort, RequestContext request) throws ResponseException {
-		Context.getService(CohortService.class).purgeCohort(cohort);
+		Context.getService(CohortService.class).purgeCohortM(cohort);
 	}
 	
 	@Override
@@ -152,7 +152,7 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 	
 	@Override
 	public CohortM getByUniqueId(String uuid) {
-		return Context.getService(CohortService.class).getCohortByUuid(uuid);
+		return Context.getService(CohortService.class).getCohortMByUuid(uuid);
 	}
 	
 	@Override
@@ -184,9 +184,9 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 		
 		if (StringUtils.isNotBlank(cohortType)) {
 			CohortTypeService typeService = Context.getService(CohortTypeService.class);
-			type = typeService.getByName(cohortType);
+			type = typeService.getCohortTypeByName(cohortType);
 			if (type == null) {
-				type = typeService.getByUuid(cohortType);
+				type = typeService.getCohortTypeByUuid(cohortType);
 			}
 			
 			if (type == null) {
@@ -198,11 +198,11 @@ public class CohortResource extends DataDelegatingCrudResource<CohortM> {
 		CohortService cohortService = Context.getService(CohortService.class);
 		
 		if (StringUtils.isNotBlank(location)) {
-			Collection<CohortM> cohorts = cohortService.findCohortByLocationUuid(location);
+			Collection<CohortM> cohorts = cohortService.findCohortMByLocationUuid(location);
 			return new NeedsPaging<>(new ArrayList<>(cohorts), context);
 		}
 		
-		List<CohortM> cohort = cohortService.findMatchingCohorts(context.getParameter("q"), attributes, type,
+		List<CohortM> cohort = cohortService.findMatchingCohortMs(context.getParameter("q"), attributes, type,
 		    context.getIncludeAll());
 		return new NeedsPaging<>(cohort, context);
 		

--- a/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/cohort/web/resource/CohortTypeResource.java
@@ -94,17 +94,18 @@ public class CohortTypeResource extends DataDelegatingCrudResource<CohortType> {
 	
 	@Override
 	public CohortType getByUniqueId(String uuidOrName) {
-		CohortType cohortType = Context.getService(CohortTypeService.class).getByUuid(uuidOrName);
+		CohortType cohortType = Context.getService(CohortTypeService.class).getCohortTypeByUuid(uuidOrName);
 		//If getByUuid is null. Try searching by name
 		if (cohortType == null) {
-			cohortType = Context.getService(CohortTypeService.class).getByName(uuidOrName);
+			cohortType = Context.getService(CohortTypeService.class).getCohortTypeByName(uuidOrName);
 		}
 		return cohortType;
 	}
 	
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-		return new NeedsPaging<>((List<CohortType>) Context.getService(CohortTypeService.class).findAll(), context);
+		return new NeedsPaging<>((List<CohortType>) Context.getService(CohortTypeService.class).findAllCohortTypes(),
+		        context);
 	}
 	
 	@PropertyGetter("display")

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortAttributeTypeResourceTest.java
@@ -88,7 +88,7 @@ public class CohortAttributeTypeResourceTest extends BaseCohortResourceTest<Coho
 	
 	@Test
 	public void shouldGetResourceByUniqueUuid() {
-		when(cohortService.getAttributeTypeByUuid(COHORT_ATTRIBUTE_TYPE_UUID)).thenReturn(cohortAttributeType);
+		when(cohortService.getCohortAttributeTypeByUuid(COHORT_ATTRIBUTE_TYPE_UUID)).thenReturn(cohortAttributeType);
 		
 		CohortAttributeType result = getResource().getByUniqueId(COHORT_ATTRIBUTE_TYPE_UUID);
 		assertThat(result, notNullValue());
@@ -98,7 +98,7 @@ public class CohortAttributeTypeResourceTest extends BaseCohortResourceTest<Coho
 	
 	@Test
 	public void shouldCreateNewResource() {
-		when(cohortService.saveAttributeType(getObject())).thenReturn(getObject());
+		when(cohortService.saveCohortAttributeType(getObject())).thenReturn(getObject());
 		
 		CohortAttributeType newlyCreatedObject = getResource().save(getObject());
 		assertThat(newlyCreatedObject, notNullValue());
@@ -108,7 +108,7 @@ public class CohortAttributeTypeResourceTest extends BaseCohortResourceTest<Coho
 	
 	@Test
 	public void shouldGetAllResources() {
-		when(cohortService.findAllAttributeTypes()).thenReturn(Collections.singletonList(getObject()));
+		when(cohortService.findAllCohortAttributeTypes()).thenReturn(Collections.singletonList(getObject()));
 		
 		PageableResult results = getResource().doGetAll(new RequestContext());
 		

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberAttributeResourceTest.java
@@ -82,7 +82,8 @@ public class CohortMemberAttributeResourceTest extends BaseCohortResourceTest<Co
 	
 	@Test
 	public void shouldGetResourceByUniqueUuid() {
-		when(cohortMemberService.getAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID)).thenReturn(cohortMemberAttribute);
+		when(cohortMemberService.getCohortMemberAttributeByUuid(COHORT_MEMBER_ATTRIBUTE_UUID))
+		        .thenReturn(cohortMemberAttribute);
 		
 		CohortMemberAttribute result = getResource().getByUniqueId(COHORT_MEMBER_ATTRIBUTE_UUID);
 		assertThat(result, notNullValue());
@@ -91,7 +92,7 @@ public class CohortMemberAttributeResourceTest extends BaseCohortResourceTest<Co
 	
 	@Test
 	public void shouldCreateNewResource() {
-		when(cohortMemberService.createAttribute(getObject())).thenReturn(getObject());
+		when(cohortMemberService.saveCohortMemberAttribute(getObject())).thenReturn(getObject());
 		
 		CohortMemberAttribute newlyCreatedObject = getResource().save(getObject());
 		assertThat(newlyCreatedObject, notNullValue());

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortMemberResourceTest.java
@@ -89,7 +89,7 @@ public class CohortMemberResourceTest extends BaseCohortResourceTest<CohortMembe
 	
 	@Test
 	public void shouldGetResourceByUniqueUuid() {
-		when(cohortMemberService.getByUuid(COHORT_MEMBER_UUID)).thenReturn(cohortMember);
+		when(cohortMemberService.getCohortMemberByUuid(COHORT_MEMBER_UUID)).thenReturn(cohortMember);
 		
 		CohortMember result = getResource().getByUniqueId(COHORT_MEMBER_UUID);
 		assertThat(result, notNullValue());
@@ -101,7 +101,7 @@ public class CohortMemberResourceTest extends BaseCohortResourceTest<CohortMembe
 		CohortM cohort = mock(CohortM.class);
 		cohortMember.setCohort(cohort);
 		
-		when(cohortMemberService.createOrUpdate(getObject())).thenReturn(getObject());
+		when(cohortMemberService.saveCohortMember(getObject())).thenReturn(getObject());
 		when(cohort.getVoided()).thenReturn(false);
 		
 		CohortMember newlyCreatedObject = getResource().save(getObject());
@@ -111,7 +111,7 @@ public class CohortMemberResourceTest extends BaseCohortResourceTest<CohortMembe
 	
 	@Test(expected = ResourceDoesNotSupportOperationException.class)
 	public void shouldGetAllResources() {
-		when(cohortMemberService.findAll()).thenReturn(Collections.singletonList(getObject()));
+		when(cohortMemberService.findAllCohortMembers()).thenReturn(Collections.singletonList(getObject()));
 		
 		getResource().getAll(new RequestContext());
 	}

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceControllerTest.java
@@ -33,7 +33,7 @@ public class CohortResourceControllerTest extends MainResourceControllerTest {
 	@Test
 	public void shouldCreateCohortWithMembers() throws Exception {
 		
-		CohortM cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		CohortM cohort = Context.getService(CohortService.class).getCohortM("cohort name");
 		assertNull(cohort);
 		
 		String json = "{ \"name\":\"cohort name\", \"description\":\"cohort description\"," + "\"cohortMembers\": [ {"
@@ -41,7 +41,7 @@ public class CohortResourceControllerTest extends MainResourceControllerTest {
 		
 		handle(newPostRequest(getURI(), json));
 		
-		cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		cohort = Context.getService(CohortService.class).getCohortM("cohort name");
 		assertNotNull(cohort);
 		assertEquals("cohort description", cohort.getDescription());
 		
@@ -53,19 +53,19 @@ public class CohortResourceControllerTest extends MainResourceControllerTest {
 	@Test
 	public void shouldUpdateCohortWhileKeepingName() throws Exception {
 		
-		CohortM cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		CohortM cohort = Context.getService(CohortService.class).getCohortM("cohort name");
 		assertNull(cohort);
 		
 		String createJson = "{ \"name\":\"cohort name\", \"description\":\"cohort description\"," + "\"cohortMembers\": [ {"
 		        + "\"patient\":\"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\"" + " } ]" + "}";
 		
 		handle(newPostRequest(getURI(), createJson));
-		cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		cohort = Context.getService(CohortService.class).getCohortM("cohort name");
 		
 		String updateJson = "{ \"name\":\"cohort name\", \"description\":\"updated cohort description\" } ]" + "}";
 		
 		handle(newPostRequest(getURI() + "/" + cohort.getUuid(), updateJson));
-		cohort = Context.getService(CohortService.class).getCohort("cohort name");
+		cohort = Context.getService(CohortService.class).getCohortM("cohort name");
 		
 		assertNotNull(cohort);
 		assertEquals("updated cohort description", cohort.getDescription());

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortResourceTest.java
@@ -79,7 +79,7 @@ public class CohortResourceTest extends BaseCohortResourceTest<CohortM, CohortRe
 	
 	@Test
 	public void shouldGetResourceByUniqueUuid() {
-		when(cohortService.getCohortByUuid(COHORT_UUID)).thenReturn(cohort);
+		when(cohortService.getCohortMByUuid(COHORT_UUID)).thenReturn(cohort);
 		
 		CohortM result = getResource().getByUniqueId(COHORT_UUID);
 		
@@ -90,7 +90,7 @@ public class CohortResourceTest extends BaseCohortResourceTest<CohortM, CohortRe
 	
 	@Test
 	public void shouldCreateNewResource() {
-		when(cohortService.saveCohort(getObject())).thenReturn(getObject());
+		when(cohortService.saveCohortM(getObject())).thenReturn(getObject());
 		
 		CohortM newlyCreatedObject = getResource().save(getObject());
 		

--- a/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortTypeResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/cohort/web/resource/CohortTypeResourceTest.java
@@ -79,7 +79,7 @@ public class CohortTypeResourceTest extends BaseCohortResourceTest<CohortType, C
 	
 	@Test
 	public void shouldGetAllResource() {
-		when(cohortTypeService.findAll()).thenReturn(Collections.singletonList(cohortType));
+		when(cohortTypeService.findAllCohortTypes()).thenReturn(Collections.singletonList(cohortType));
 		
 		PageableResult result = getResource().doGetAll(new RequestContext());
 		assertThat(result, notNullValue());
@@ -87,7 +87,7 @@ public class CohortTypeResourceTest extends BaseCohortResourceTest<CohortType, C
 	
 	@Test
 	public void shouldGetResourceByUniqueUuid() {
-		when(cohortTypeService.getByUuid(COHORT_TYPE_UUID)).thenReturn(cohortType);
+		when(cohortTypeService.getCohortTypeByUuid(COHORT_TYPE_UUID)).thenReturn(cohortType);
 		
 		CohortType result = getResource().getByUniqueId(COHORT_TYPE_UUID);
 		assertThat(result, notNullValue());

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
                 <type>jar</type>
                 <scope>provided</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.web</groupId>
                 <artifactId>openmrs-web</artifactId>
@@ -74,7 +73,6 @@
                 <type>jar</type>
                 <scope>provided</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.api</groupId>
                 <artifactId>openmrs-api</artifactId>
@@ -82,7 +80,6 @@
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.web</groupId>
                 <artifactId>openmrs-web</artifactId>
@@ -90,28 +87,24 @@
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>webservices.rest-omod</artifactId>
                 <version>${webservicesRestVersion}</version>
                 <scope>provided</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>webservices.rest-omod-common</artifactId>
                 <version>${webservicesRestVersion}</version>
                 <scope>provided</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>legacyui-omod</artifactId>
                 <version>${legacyUiVersion}</version>
                 <scope>provided</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.test</groupId>
                 <artifactId>openmrs-test</artifactId>
@@ -137,7 +130,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>webservices.rest-omod-common</artifactId>
@@ -205,29 +197,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.liquibase</groupId>
-                    <artifactId>liquibase-maven-plugin</artifactId>
-                    <version>4.3.5</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>mysql</groupId>
-                            <artifactId>mysql-connector-java</artifactId>
-                            <version>5.1.49</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <propertyFile>api/src/main/resources/liquibase.properties</propertyFile>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>clearCheckSums</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
@@ -280,6 +249,13 @@
                             </goals>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-utils</artifactId>
+                            <version>3.3.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>


### PR DESCRIPTION
Does what the title suggests. Note that this renames a good amount of the API, but ensures that we are using OpenMRS standard AOP functions for saving, voiding, and deleting. Also fixed some tests that were ignored.